### PR TITLE
Make `program::graph` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,5 +16,5 @@
 pub mod expression;
 pub mod instruction;
 mod macros;
-pub mod parser;
+pub(crate) mod parser;
 pub mod program;

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -201,8 +201,3 @@ pub fn skip_newlines_and_comments<'a>(input: ParserInput<'a>) -> ParserResult<'a
     )))(input)?;
     Ok((input, ()))
 }
-
-/// Parse ahead to the next non-newline token.
-pub fn skip_newlines<'a>(input: ParserInput<'a>) -> ParserResult<'a, ()> {
-    many0(token!(NewLine))(input).map(|(input, _)| (input, ()))
-}

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -43,17 +43,6 @@ pub enum ErrorKind {
         actual: Token,
         expected: String,
     },
-    /// An unknown identifier was encountered
-    UnknownIdentifier,
-
-    /// An invalid literal was encountered.
-    ///
-    /// When encountered, this generally means a bug exists in the data that
-    /// was passed in or the parsing logic.
-    InvalidLiteral,
-
-    /// A full parse was requested, but data was left over after parsing finished.
-    Partial,
 
     /// Tried to parse a kind of command and couldn't
     /// TODO: Wrap actual error, the string is a lifetime cop-out
@@ -61,9 +50,6 @@ pub enum ErrorKind {
         command: Command,
         error: String,
     },
-
-    /// Tried to parse a gate and couldn't
-    InvalidGate,
 
     /// Unexpected start of an instruction
     NotACommandOrGate,

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -41,11 +41,9 @@ pub enum Token {
     LBracket,
     LParenthesis,
     NonBlocking,
-    MathematicalFunction(MathematicalFunction),
     Matrix,
     Modifier(Modifier),
     NewLine,
-    Offset,
     Operator(Operator),
     Permutation,
     RBracket,
@@ -119,15 +117,6 @@ pub enum DataType {
     Octet,
     Real,
     Integer,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum MathematicalFunction {
-    Cis,
-    Cos,
-    Exp,
-    Sin,
-    Sqrt,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,16 +17,19 @@ mod command;
 mod gate;
 mod macros;
 
-pub mod common;
-pub mod error;
-pub mod expression;
-pub mod instruction;
-pub mod lexer;
+mod common;
+mod error;
+mod expression;
+mod instruction;
+mod lexer;
+
+pub(crate) use instruction::parse_instructions;
+pub(crate) use lexer::lex;
 
 use nom::IResult;
 
 use error::Error;
 use lexer::Token;
 
-pub type ParserInput<'a> = &'a [Token];
-pub type ParserResult<'a, R> = IResult<&'a [Token], R, Error<&'a [Token]>>;
+type ParserInput<'a> = &'a [Token];
+type ParserResult<'a, R> = IResult<&'a [Token], R, Error<&'a [Token]>>;

--- a/src/program/graph.rs
+++ b/src/program/graph.rs
@@ -26,11 +26,12 @@ use indexmap::IndexMap;
 #[derive(Debug, Clone)]
 pub enum ScheduleErrorVariant {
     DuplicateLabel,
-    DurationNotRealConstant,
-    DurationNotApplicable,
-    InvalidFrame,
     UncalibratedInstruction,
-    UnscheduleableInstruction,
+    UnschedulableInstruction,
+    // Note: these may be restored once enforced
+    // DurationNotRealConstant,
+    // DurationNotApplicable,
+    // InvalidFrame,
 }
 
 #[derive(Debug, Clone)]
@@ -39,7 +40,7 @@ pub struct ScheduleError {
     variant: ScheduleErrorVariant,
 }
 
-type ScheduleResult<T> = Result<T, ScheduleError>;
+pub type ScheduleResult<T> = Result<T, ScheduleError>;
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Hash, Ord)]
 pub enum ScheduledGraphNode {
@@ -211,7 +212,7 @@ impl InstructionBlock {
                 InstructionRole::RFControl => {
                     let frames = Self::get_frames(instruction, program).ok_or(ScheduleError {
                         instruction: instruction.clone(),
-                        variant: ScheduleErrorVariant::UnscheduleableInstruction,
+                        variant: ScheduleErrorVariant::UnschedulableInstruction,
                     })?;
 
                     // Mark a dependency on
@@ -225,11 +226,11 @@ impl InstructionBlock {
                 }
                 InstructionRole::ControlFlow => Err(ScheduleError {
                     instruction: instruction.clone(),
-                    variant: ScheduleErrorVariant::UnscheduleableInstruction,
+                    variant: ScheduleErrorVariant::UnschedulableInstruction,
                 }),
                 InstructionRole::ProgramComposition => Err(ScheduleError {
                     instruction: instruction.clone(),
-                    variant: ScheduleErrorVariant::UnscheduleableInstruction,
+                    variant: ScheduleErrorVariant::UnschedulableInstruction,
                 }),
             }?;
 
@@ -413,7 +414,7 @@ impl ScheduledProgram {
                 | Instruction::MeasureCalibrationDefinition { .. }
                 | Instruction::WaveformDefinition { .. } => Err(ScheduleError {
                     instruction: instruction.clone(),
-                    variant: ScheduleErrorVariant::UnscheduleableInstruction,
+                    variant: ScheduleErrorVariant::UnschedulableInstruction,
                 }),
 
                 Instruction::Pragma { .. } => {

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -16,20 +16,20 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use frame::FrameSet;
-
 use crate::{
     instruction::{FrameIdentifier, Instruction, Waveform},
-    parser::{instruction::parse_instructions, lexer},
+    parser::{lex, parse_instructions},
 };
 
-use self::calibration::CalibrationSet;
-use self::memory::MemoryRegion;
+mod calibration;
+mod frame;
+mod graph;
+mod memory;
 
-pub mod calibration;
-pub mod frame;
-pub mod graph;
-pub mod memory;
+pub use self::calibration::CalibrationSet;
+pub use self::frame::FrameSet;
+pub use self::graph::{InstructionBlock, ScheduleError, ScheduleResult, ScheduledProgram};
+pub use self::memory::MemoryRegion;
 
 /// A Quil Program instance describes a quantum program with metadata used in execution.
 ///
@@ -170,7 +170,7 @@ impl Program {
 impl FromStr for Program {
     type Err = nom::Err<String>;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let lexed = lexer::lex(s);
+        let lexed = lex(s);
         let (_, instructions) = parse_instructions(&lexed).map_err(|err| match err {
             nom::Err::Incomplete(_) => nom::Err::Error("incomplete".to_owned()),
             nom::Err::Error(error) => nom::Err::Error(format!("{:?}", error)),


### PR DESCRIPTION
This fixes an oversight from #2 which prevented access to necessary types in `program::graph`. That _could_ be fixed by re-exporting from `program` but there are enough of them, and they're cohesive around the concept of a `graph`, so I'll just expose the entire `graph` module itself.

I took the liberty of removing the `pub use graph::...` statement from the program module as well, which is a breaking change but in the interest of avoiding further confusion, I'll merge this as a fix and a patch version bump.