### PR TITLE
Make `program::graph` public

### DIFF
--- a/src/program/graph.rs
+++ b/src/program/graph.rs
@@ -1,3 +1,5 @@
+//! Utilities for analysis of the dependency graph of a Quil Program
+
 /**
  * Copyright 2021 Rigetti Computing
  *

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -23,12 +23,11 @@ use crate::{
 
 mod calibration;
 mod frame;
-mod graph;
+pub mod graph;
 mod memory;
 
 pub use self::calibration::CalibrationSet;
 pub use self::frame::FrameSet;
-pub use self::graph::{InstructionBlock, ScheduleError, ScheduleResult, ScheduledProgram};
 pub use self::memory::MemoryRegion;
 
 /// A Quil Program instance describes a quantum program with metadata used in execution.


### PR DESCRIPTION
This fixes an oversight from #2 which prevented access to necessary types in `program::graph`. That _could_ be fixed by re-exporting from `program` but there are enough of them, and they're cohesive around the concept of a `graph`, so I'll just expose the entire `graph` module itself.

I took the liberty of removing the `pub use graph::...` statement from the program module as well, which is a breaking change but in the interest of avoiding further confusion, I'll merge this as a fix and a patch version bump.