### PR TITLE
Breaking: remove parse_qubits and parse_variable_qubits

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -479,7 +479,7 @@ impl fmt::Display for Instruction {
             } => {
                 let mut parameter_str: String = parameters
                     .iter()
-                    .map(|p| format!("%{}", p.to_string()))
+                    .map(|p| format!("%{}", p))
                     .collect::<Vec<String>>()
                     .join(", ");
                 if !parameter_str.is_empty() {

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -22,18 +22,17 @@ use nom::{
 use super::{
     common::{
         self, parse_frame_attribute, parse_frame_identifier, parse_gate_modifier,
-        parse_memory_reference, parse_qubits, parse_waveform_invocation,
+        parse_memory_reference, parse_qubit, parse_waveform_invocation,
     },
     expression::parse_expression,
     instruction, ParserInput, ParserResult,
 };
-use crate::parser::common::parse_variable_qubits;
+use crate::parser::common::parse_variable_qubit;
 use crate::parser::instruction::parse_block;
 use crate::{
     instruction::{
         ArithmeticOperand, ArithmeticOperator, Calibration, FrameIdentifier, Instruction, Waveform,
     },
-    parser::common::parse_qubit,
     token,
 };
 
@@ -96,7 +95,7 @@ pub fn parse_defcal<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction>
         token!(RParenthesis),
     ))(input)?;
     let parameters = parameters.unwrap_or_default();
-    let (input, qubits) = parse_qubits(input)?;
+    let (input, qubits) = many0(parse_qubit)(input)?;
     let (input, _) = token!(Colon)(input)?;
     let (input, instructions) = instruction::parse_block(input)?;
     Ok((
@@ -161,7 +160,7 @@ pub fn parse_defcircuit<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruct
         token!(RParenthesis),
     ))(input)?;
     let parameters = parameters.unwrap_or_default();
-    let (input, qubit_variables) = parse_variable_qubits(input)?;
+    let (input, qubit_variables) = many0(parse_variable_qubit)(input)?;
     let (input, _) = token!(Colon)(input)?;
     let (input, instructions) = parse_block(input)?;
 
@@ -178,7 +177,7 @@ pub fn parse_defcircuit<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruct
 
 /// Parse the contents of a `DELAY` instruction.
 pub fn parse_delay<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
-    let (input, qubits) = parse_qubits(input)?;
+    let (input, qubits) = many0(parse_qubit)(input)?;
     let (input, frame_names) = many0(token!(String(v)))(input)?;
     let (input, duration) = parse_expression(input)?;
 
@@ -304,7 +303,7 @@ pub fn parse_pulse<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> 
     };
     // TODO (Kalan): Actually check that this is a pulse
     let (input, _) = token!(Command(pulse))(input)?;
-    let (input, qubits) = parse_qubits(input)?;
+    let (input, qubits) = many0(parse_qubit)(input)?;
     let (input, name) = token!(String(v))(input)?;
     let (input, waveform) = parse_waveform_invocation(input)?;
 

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -165,11 +165,6 @@ pub fn parse_qubit(input: ParserInput) -> ParserResult<Qubit> {
     }
 }
 
-/// Parse zero or more qubits in sequence.
-pub fn parse_qubits(input: ParserInput) -> ParserResult<Vec<Qubit>> {
-    many0(parse_qubit)(input)
-}
-
 /// Parse a variable qubit (i.e. a named qubit)
 pub fn parse_variable_qubit(input: ParserInput) -> ParserResult<String> {
     match input.split_first() {
@@ -183,11 +178,6 @@ pub fn parse_variable_qubit(input: ParserInput) -> ParserResult<String> {
             expected_token!(input, other_token, stringify!($expected_variant).to_owned())
         }
     }
-}
-
-/// Parse zero or more variable qubits in sequence
-pub fn parse_variable_qubits(input: ParserInput) -> ParserResult<Vec<String>> {
-    many0(parse_variable_qubit)(input)
 }
 
 /// Parse a "vector" which is an integer index, such as `[0]`

--- a/src/parser/gate.rs
+++ b/src/parser/gate.rs
@@ -33,7 +33,7 @@ pub fn parse_gate<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
         token!(RParenthesis),
     ))(input)?;
     let parameters = parameters.unwrap_or_default();
-    let (input, qubits) = common::parse_qubits(input)?;
+    let (input, qubits) = many0(common::parse_qubit)(input)?;
     Ok((
         input,
         Instruction::Gate {


### PR DESCRIPTION
These two functions strike me as unnecessary (we can always use `nom::many0` directly) and a bit arbitrary (why `parse_qubits` but no `parse_gate_modifiers`, e.g.?).