### PR TITLE
Fix: Unbox calibrations and waveform invocations

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -246,11 +246,11 @@ pub enum Instruction {
     Reset {
         qubit: Option<Qubit>,
     },
-    CalibrationDefinition(Box<Calibration>),
+    CalibrationDefinition(Calibration),
     Capture {
         frame: FrameIdentifier,
         memory_reference: MemoryReference,
-        waveform: Box<WaveformInvocation>,
+        waveform: WaveformInvocation,
     },
     Delay {
         duration: Expression,
@@ -277,7 +277,7 @@ pub enum Instruction {
     Pulse {
         blocking: bool,
         frame: FrameIdentifier,
-        waveform: Box<WaveformInvocation>,
+        waveform: WaveformInvocation,
     },
     RawCapture {
         frame: FrameIdentifier,

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -80,7 +80,7 @@ pub fn parse_capture(input: ParserInput) -> ParserResult<Instruction> {
         input,
         Instruction::Capture {
             frame,
-            waveform: Box::new(waveform),
+            waveform,
             memory_reference,
         },
     ))
@@ -101,13 +101,13 @@ pub fn parse_defcal<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction>
     let (input, instructions) = instruction::parse_block(input)?;
     Ok((
         input,
-        Instruction::CalibrationDefinition(Box::new(Calibration {
+        Instruction::CalibrationDefinition(Calibration {
             instructions,
             modifiers,
             name,
             parameters,
             qubits,
-        })),
+        }),
     ))
 }
 
@@ -313,7 +313,7 @@ pub fn parse_pulse<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> 
         Instruction::Pulse {
             blocking,
             frame: FrameIdentifier { name, qubits },
-            waveform: Box::new(waveform),
+            waveform,
         },
     ))
 }

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -239,10 +239,10 @@ mod tests {
                     name: "rx".to_owned(),
                     qubits: vec![Qubit::Fixed(0)]
                 },
-                waveform: Box::new(WaveformInvocation {
+                waveform: WaveformInvocation {
                     name: "my_custom_waveform".to_owned(),
                     parameters: HashMap::new()
-                }),
+                },
                 memory_reference: MemoryReference {
                     name: "ro".to_owned(),
                     index: 0
@@ -313,7 +313,7 @@ mod tests {
         parametric_calibration,
         parse_instructions,
         "DEFCAL RX(%theta) %qubit:\n\tPULSE 1 \"xy\" custom_waveform(a: 1)",
-        vec![Instruction::CalibrationDefinition(Box::new(Calibration {
+        vec![Instruction::CalibrationDefinition(Calibration {
             name: "RX".to_owned(),
             parameters: vec![Expression::Variable("theta".to_owned())],
             qubits: vec![Qubit::Variable("qubit".to_owned())],
@@ -324,15 +324,15 @@ mod tests {
                     name: "xy".to_owned(),
                     qubits: vec![Qubit::Fixed(1)]
                 },
-                waveform: Box::new(WaveformInvocation {
+                waveform: WaveformInvocation {
                     name: "custom_waveform".to_owned(),
                     parameters: [("a".to_owned(), Expression::Number(crate::real![1f64]))]
                         .iter()
                         .cloned()
                         .collect()
-                })
+                }
             }]
-        }))]
+        })]
     );
 
     make_test!(
@@ -384,10 +384,10 @@ mod tests {
                     name: "xy".to_owned(),
                     qubits: vec![Qubit::Fixed(0)]
                 },
-                waveform: Box::new(WaveformInvocation {
+                waveform: WaveformInvocation {
                     name: "custom".to_owned(),
                     parameters: HashMap::new()
-                })
+                }
             },
             Instruction::Pulse {
                 blocking: false,
@@ -395,10 +395,10 @@ mod tests {
                     name: "xy".to_owned(),
                     qubits: vec![Qubit::Fixed(0)]
                 },
-                waveform: Box::new(WaveformInvocation {
+                waveform: WaveformInvocation {
                     name: "custom".to_owned(),
                     parameters: HashMap::new()
-                })
+                }
             }
         ]
     );

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -213,7 +213,7 @@ impl CalibrationSet {
     pub fn to_instructions(&self) -> Vec<Instruction> {
         self.calibrations
             .iter()
-            .map(|c| Instruction::CalibrationDefinition(Box::new(c.clone())))
+            .map(|c| Instruction::CalibrationDefinition(c.clone()))
             .collect()
     }
 }

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -61,7 +61,7 @@ impl Program {
 
         match instruction {
             CalibrationDefinition(calibration) => {
-                self.calibrations.push(*calibration);
+                self.calibrations.push(calibration);
             }
             FrameDefinition {
                 identifier,


### PR DESCRIPTION
Both `CalibrationDefinition` and `Instruction` have some unnecessary `Box`es—around a `Calibration` in the former and a `WaveformInvocation` in the latter. This PR removes them, so only `Expression`s have a `Box` in them (and this one is necessary due to recursive definitions).

Resolves #15, first observed in #11