### PR TITLE
Update: change Qubit::Fixed, Token::Integer, Vector.length, MemoryRefence.index to usize

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -162,7 +162,7 @@ impl fmt::Display for ScalarType {
 #[derive(Clone, Debug, Hash, PartialEq)]
 pub struct Vector {
     pub data_type: ScalarType,
-    pub length: u64,
+    pub length: usize,
 }
 
 impl fmt::Display for Vector {
@@ -202,7 +202,7 @@ impl fmt::Display for WaveformInvocation {
 #[derive(Clone, Debug, Hash, PartialEq)]
 pub struct MemoryReference {
     pub name: String,
-    pub index: u64,
+    pub index: usize,
 }
 
 impl Eq for MemoryReference {}
@@ -669,7 +669,7 @@ impl fmt::Display for Instruction {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum Qubit {
-    Fixed(u64),
+    Fixed(usize),
     Variable(String),
 }
 

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -36,7 +36,7 @@ pub enum Token {
     Float(f64),
     Identifier(String),
     Indentation,
-    Integer(u64),
+    Integer(usize),
     Label(String),
     LBracket,
     LParenthesis,
@@ -292,7 +292,7 @@ fn lex_number(input: &str) -> LexResult {
     Ok((
         input,
         match integer_parse_result {
-            Ok(_) => Token::Integer(float_string.parse::<u64>().unwrap()),
+            Ok(_) => Token::Integer(float_string.parse::<usize>().unwrap()),
             Err(_) => Token::Float(double(float_string)?.1 as f64),
         },
     ))


### PR DESCRIPTION
This was originally meant to only address #8, changing `Qubit::Fixed` from `u64` to `usize`. In doing so, the quickest fix was to also update `Token::Integer` to `usize`, which meant that to make the compiler happy, I needed to make `Vector.length` and `MemoryReference.index` into `usize`s too. I'm morally OK with this, as both `length` and `index` to me _sound_ like they should be of type `usize` instead of `u64`, but I leave it to the reviewer(s) whether this PR should be merged or burned with fire.