### PR TITLE
Feature: Add proptest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 node_modules
+tags

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ serde = { version = "1.0.125", features = ["derive"] }
 
 [dev-dependencies]
 insta = "1.7.1"
+paste = "1.0.5"
+proptest = "1.0.0"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,3 +31,27 @@ macro_rules! imag {
         Complex64::new(0f64, $value)
     }};
 }
+
+/// Construct round-tripping test for Data -> String -> Parsed Data
+#[macro_export]
+macro_rules! roundtrip_proptest {
+    ($name:ident, $generator:expr, $parser:expr) => {
+        paste::paste! {
+            #[allow(unused_imports)]
+            mod [<$name _roundtrip>] {
+                use super::*;
+                use proptest::prelude::*;
+                proptest! {
+                    #[test]
+                    fn roundtrip(datum in $generator) {
+                        let string = datum.to_string();
+                        let lexed = lex(&string);
+                        let parsed = $parser(&lexed);
+                        prop_assert!(parsed.is_ok());
+                        prop_assert_eq!(datum, parsed.unwrap().1);
+                    }
+                }
+            }
+        }
+    };
+}

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -223,9 +223,10 @@ pub fn skip_newlines_and_comments<'a>(input: ParserInput<'a>) -> ParserResult<'a
 
 #[cfg(test)]
 mod tests {
-    use crate::{expression::Expression, instruction::MemoryReference, parser::lex, real};
-
-    use super::parse_waveform_invocation;
+    use super::*;
+    use crate::{
+        expression::Expression, instruction::MemoryReference, parser::lex, real, roundtrip_proptest,
+    };
 
     #[test]
     fn waveform_invocation() {
@@ -250,4 +251,14 @@ mod tests {
             .collect()
         )
     }
+
+    roundtrip_proptest!(
+        qubit,
+        prop_oneof![
+            any::<u64>().prop_map(Qubit::Fixed),
+            "[a-z][a-z0-9]+".prop_map(Qubit::Variable)
+        ],
+        parse_qubit
+    );
+    roundtrip_proptest!(variable_qubit, "[a-z][a-z0-9]+", parse_variable_qubit);
 }


### PR DESCRIPTION
*Note: I'm putting this one up as an early draft prior to sinking more time into it. If y'all like it, great! I'll keep going. If not, I'll be happy to throw away this PR & branch.*

[I've previously mentioned](https://github.com/rigetti/quil-rust/pull/11#discussion_r674219699) being interested in adding property-based testing using [`proptest`](https://github.com/AltSysrq/proptest) to do the heavy lifting for us. So far, this PR adds:

- two new `dev` dependencies, viz.
  - [`proptest`](https://github.com/AltSysrq/proptest) to do the testing,
  -  and [`paste`](https://github.com/dtolnay/paste) to do some macro naming tomfoolery
- one new testing macro called `roundtrip_proptest!` to assert that `parse_thing(lex(thing.to_string)) == thing`
- two examples of using `roundtrip_proptest!` to start, one for `parse_qubit` and one for `parse_variable_qubit`

The `roundtrip_proptest!` macro takes a name, a `proptest` generator of valid data, and a parsing function:

```rust
roundtrip_proptest!(thing, any<data>().prop_map(Thing::stuff), parse_thing);
```

and expands that into

```rust
mod thing_roundtrip {
    use super::*;
    use proptest::prelude::*;
    proptest! {
        #[test]
        fn roundtrip(datum in any<data>().prop_map(Thing::stuf)) {
            let string = datum.to_string();
            let lexed = lex(&string);
            let parsed = parse_thing(&lexed);
            prop_assert!(parsed.is_ok());
            prop_assert_eq!(datum, parsed.unwrap().1);
            }
        }
}
```

As an example, I found something that wasn't clear to me from the docstrings when running these tests. The docs for `parse_qubit` say that a qubit designator can be
> an integer (`1`), variable (`%q1`), or identifier (`q1`).
So I wrote my test:

```rust
roundtrip_proptest!(
    qubit,
    prop_oneof![
        any::<u64>().prop_map(Qubit::Fixed),
        "%[a-z][a-z0-9]+".prop_map(Qubit::Variable)
    ],
    parse_qubit
);
```
and it failed!

```
<SNIP>
thread 'parser::common::tests::qubit_roundtrip::roundtrip' panicked at 'Test failed: assertion failed: `(left == right)`
  left: `Variable("%a0")`,
 right: `Variable("a0")` at quil-rust/src/parser/common.rs:255; minimal failing input: datum = Variable("%a0")
<SNIP>
```

I didn't know that the lexer removes the percent symbol. Changing the generator for that case to `"[a-z][a-z0-9]+".prop_map(Qubit::Variable)` makes the test pass.