### PR TITLE
Breaking: Instruction variants are top-level structs

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -261,9 +261,6 @@ pub struct Reset {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct CalibrationDefinition(pub Calibration);
-
-#[derive(Clone, Debug, PartialEq)]
 pub struct Capture {
     pub blocking: bool,
     pub frame: FrameIdentifier,
@@ -424,7 +421,7 @@ pub enum Instruction {
     Declaration(Declaration),
     Measurement(Measurement),
     Reset(Reset),
-    CalibrationDefinition(CalibrationDefinition),
+    CalibrationDefinition(Calibration),
     Capture(Capture),
     Delay(Delay),
     Fence(Fence),
@@ -463,7 +460,7 @@ pub enum InstructionRole {
 impl From<&Instruction> for InstructionRole {
     fn from(instruction: &Instruction) -> Self {
         match instruction {
-            Instruction::CalibrationDefinition(CalibrationDefinition(_))
+            Instruction::CalibrationDefinition(_)
             | Instruction::CircuitDefinition(CircuitDefinition { .. })
             | Instruction::Declaration(Declaration { .. })
             | Instruction::FrameDefinition(FrameDefinition { .. })
@@ -564,7 +561,7 @@ impl fmt::Display for Instruction {
                 destination,
                 source,
             }) => write!(f, "{} {} {}", operator, destination, source),
-            Instruction::CalibrationDefinition(CalibrationDefinition(calibration)) => {
+            Instruction::CalibrationDefinition(calibration) => {
                 let parameter_str = get_expression_parameter_string(&calibration.parameters);
                 write!(
                     f,

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -218,142 +218,238 @@ impl fmt::Display for MemoryReference {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct Gate {
+    pub name: String,
+    pub parameters: Vec<Expression>,
+    pub qubits: Vec<Qubit>,
+    pub modifiers: Vec<GateModifier>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CircuitDefinition {
+    pub name: String,
+    pub parameters: Vec<String>,
+    // These cannot be fixed qubits and thus are not typed as `Qubit`
+    pub qubit_variables: Vec<String>,
+    pub instructions: Vec<Instruction>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GateDefinition {
+    pub name: String,
+    pub parameters: Vec<String>,
+    pub matrix: Vec<Vec<Expression>>,
+    pub r#type: GateType,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Declaration {
+    pub name: String,
+    pub size: Vector,
+    pub sharing: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Measurement {
+    pub qubit: Qubit,
+    pub target: Option<MemoryReference>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Reset {
+    pub qubit: Option<Qubit>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CalibrationDefinition(pub Calibration);
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Capture {
+    pub blocking: bool,
+    pub frame: FrameIdentifier,
+    pub memory_reference: MemoryReference,
+    pub waveform: WaveformInvocation,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Delay {
+    pub duration: Expression,
+    pub frame_names: Vec<String>,
+    pub qubits: Vec<Qubit>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Fence {
+    pub qubits: Vec<Qubit>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FrameDefinition {
+    pub identifier: FrameIdentifier,
+    pub attributes: HashMap<String, AttributeValue>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MeasureCalibrationDefinition {
+    pub qubit: Option<Qubit>,
+    pub parameter: String,
+    pub instructions: Vec<Instruction>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Pragma {
+    pub name: String,
+    pub arguments: Vec<String>,
+    pub data: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Pulse {
+    pub blocking: bool,
+    pub frame: FrameIdentifier,
+    pub waveform: WaveformInvocation,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RawCapture {
+    pub blocking: bool,
+    pub frame: FrameIdentifier,
+    pub duration: Expression,
+    pub memory_reference: MemoryReference,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SetFrequency {
+    pub frame: FrameIdentifier,
+    pub frequency: Expression,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SetPhase {
+    pub frame: FrameIdentifier,
+    pub phase: Expression,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SetScale {
+    pub frame: FrameIdentifier,
+    pub scale: Expression,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ShiftFrequency {
+    pub frame: FrameIdentifier,
+    pub frequency: Expression,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ShiftPhase {
+    pub frame: FrameIdentifier,
+    pub phase: Expression,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwapPhases {
+    pub frame_1: FrameIdentifier,
+    pub frame_2: FrameIdentifier,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct WaveformDefinition {
+    pub name: String,
+    pub definition: Waveform,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Arithmetic {
+    pub operator: ArithmeticOperator,
+    pub destination: ArithmeticOperand,
+    pub source: ArithmeticOperand,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Halt;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Label(pub String);
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Move {
+    pub destination: ArithmeticOperand,
+    pub source: ArithmeticOperand,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Exchange {
+    pub left: ArithmeticOperand,
+    pub right: ArithmeticOperand,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Load {
+    pub destination: MemoryReference,
+    pub source: String,
+    pub offset: MemoryReference,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Store {
+    pub destination: String,
+    pub offset: MemoryReference,
+    pub source: ArithmeticOperand,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Jump {
+    pub target: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct JumpWhen {
+    pub target: String,
+    pub condition: MemoryReference,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct JumpUnless {
+    pub target: String,
+    pub condition: MemoryReference,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub enum Instruction {
-    Gate {
-        name: String,
-        parameters: Vec<Expression>,
-        qubits: Vec<Qubit>,
-        modifiers: Vec<GateModifier>,
-    },
-    CircuitDefinition {
-        name: String,
-        parameters: Vec<String>,
-        // These cannot be fixed qubits and thus are not typed as `Qubit`
-        qubit_variables: Vec<String>,
-        instructions: Vec<Instruction>,
-    },
-    GateDefinition {
-        name: String,
-        parameters: Vec<String>,
-        matrix: Vec<Vec<Expression>>,
-        r#type: GateType,
-    },
-    Declaration {
-        name: String,
-        size: Vector,
-        sharing: Option<String>,
-    },
-    Measurement {
-        qubit: Qubit,
-        target: Option<MemoryReference>,
-    },
-    Reset {
-        qubit: Option<Qubit>,
-    },
-    CalibrationDefinition(Calibration),
-    Capture {
-        blocking: bool,
-        frame: FrameIdentifier,
-        memory_reference: MemoryReference,
-        waveform: WaveformInvocation,
-    },
-    Delay {
-        duration: Expression,
-        frame_names: Vec<String>,
-        qubits: Vec<Qubit>,
-    },
-    Fence {
-        qubits: Vec<Qubit>,
-    },
-    FrameDefinition {
-        identifier: FrameIdentifier,
-        attributes: HashMap<String, AttributeValue>,
-    },
-    MeasureCalibrationDefinition {
-        qubit: Option<Qubit>,
-        parameter: String,
-        instructions: Vec<Instruction>,
-    },
-    Pragma {
-        name: String,
-        arguments: Vec<String>,
-        data: Option<String>,
-    },
-    Pulse {
-        blocking: bool,
-        frame: FrameIdentifier,
-        waveform: WaveformInvocation,
-    },
-    RawCapture {
-        blocking: bool,
-        frame: FrameIdentifier,
-        duration: Expression,
-        memory_reference: MemoryReference,
-    },
-    SetFrequency {
-        frame: FrameIdentifier,
-        frequency: Expression,
-    },
-    SetPhase {
-        frame: FrameIdentifier,
-        phase: Expression,
-    },
-    SetScale {
-        frame: FrameIdentifier,
-        scale: Expression,
-    },
-    ShiftFrequency {
-        frame: FrameIdentifier,
-        frequency: Expression,
-    },
-    ShiftPhase {
-        frame: FrameIdentifier,
-        phase: Expression,
-    },
-    SwapPhases {
-        frame_1: FrameIdentifier,
-        frame_2: FrameIdentifier,
-    },
-    WaveformDefinition {
-        name: String,
-        definition: Waveform,
-    },
-    Arithmetic {
-        operator: ArithmeticOperator,
-        destination: ArithmeticOperand,
-        source: ArithmeticOperand,
-    },
-    Halt,
-    Label(String),
-    Move {
-        destination: ArithmeticOperand,
-        source: ArithmeticOperand,
-    },
-    Exchange {
-        left: ArithmeticOperand,
-        right: ArithmeticOperand,
-    },
-    Load {
-        destination: MemoryReference,
-        source: String,
-        offset: MemoryReference,
-    },
-    Store {
-        destination: String,
-        offset: MemoryReference,
-        source: ArithmeticOperand,
-    },
-    Jump {
-        target: String,
-    },
-    JumpWhen {
-        target: String,
-        condition: MemoryReference,
-    },
-    JumpUnless {
-        target: String,
-        condition: MemoryReference,
-    },
+    Gate(Gate),
+    CircuitDefinition(CircuitDefinition),
+    GateDefinition(GateDefinition),
+    Declaration(Declaration),
+    Measurement(Measurement),
+    Reset(Reset),
+    CalibrationDefinition(CalibrationDefinition),
+    Capture(Capture),
+    Delay(Delay),
+    Fence(Fence),
+    FrameDefinition(FrameDefinition),
+    MeasureCalibrationDefinition(MeasureCalibrationDefinition),
+    Pragma(Pragma),
+    Pulse(Pulse),
+    RawCapture(RawCapture),
+    SetFrequency(SetFrequency),
+    SetPhase(SetPhase),
+    SetScale(SetScale),
+    ShiftFrequency(ShiftFrequency),
+    ShiftPhase(ShiftPhase),
+    SwapPhases(SwapPhases),
+    WaveformDefinition(WaveformDefinition),
+    Arithmetic(Arithmetic),
+    Halt(Halt),
+    Label(Label),
+    Move(Move),
+    Exchange(Exchange),
+    Load(Load),
+    Store(Store),
+    Jump(Jump),
+    JumpWhen(JumpWhen),
+    JumpUnless(JumpUnless),
 }
 
 #[derive(Clone, Debug)]
@@ -367,38 +463,40 @@ pub enum InstructionRole {
 impl From<&Instruction> for InstructionRole {
     fn from(instruction: &Instruction) -> Self {
         match instruction {
-            Instruction::CalibrationDefinition(_)
-            | Instruction::CircuitDefinition { .. }
-            | Instruction::Declaration { .. }
-            | Instruction::FrameDefinition { .. }
-            | Instruction::Gate { .. }
-            | Instruction::GateDefinition { .. }
-            | Instruction::Label(_)
-            | Instruction::MeasureCalibrationDefinition { .. }
-            | Instruction::Measurement { .. }
-            | Instruction::Pragma { .. }
-            | Instruction::WaveformDefinition { .. } => InstructionRole::ProgramComposition,
-            Instruction::Reset { .. }
-            | Instruction::Capture { .. }
-            | Instruction::Delay { .. }
-            | Instruction::Fence { .. }
-            | Instruction::Pulse { .. }
-            | Instruction::RawCapture { .. }
-            | Instruction::SetFrequency { .. }
-            | Instruction::SetPhase { .. }
-            | Instruction::SetScale { .. }
-            | Instruction::ShiftFrequency { .. }
-            | Instruction::ShiftPhase { .. }
-            | Instruction::SwapPhases { .. } => InstructionRole::RFControl,
-            Instruction::Arithmetic { .. }
-            | Instruction::Move { .. }
-            | Instruction::Exchange { .. }
-            | Instruction::Load { .. }
+            Instruction::CalibrationDefinition(CalibrationDefinition(_))
+            | Instruction::CircuitDefinition(CircuitDefinition { .. })
+            | Instruction::Declaration(Declaration { .. })
+            | Instruction::FrameDefinition(FrameDefinition { .. })
+            | Instruction::Gate(Gate { .. })
+            | Instruction::GateDefinition(GateDefinition { .. })
+            | Instruction::Label(Label(_))
+            | Instruction::MeasureCalibrationDefinition(MeasureCalibrationDefinition { .. })
+            | Instruction::Measurement(Measurement { .. })
+            | Instruction::Pragma(Pragma { .. })
+            | Instruction::WaveformDefinition(WaveformDefinition { .. }) => {
+                InstructionRole::ProgramComposition
+            }
+            Instruction::Reset(Reset { .. })
+            | Instruction::Capture(Capture { .. })
+            | Instruction::Delay(Delay { .. })
+            | Instruction::Fence(Fence { .. })
+            | Instruction::Pulse(Pulse { .. })
+            | Instruction::RawCapture(RawCapture { .. })
+            | Instruction::SetFrequency(SetFrequency { .. })
+            | Instruction::SetPhase(SetPhase { .. })
+            | Instruction::SetScale(SetScale { .. })
+            | Instruction::ShiftFrequency(ShiftFrequency { .. })
+            | Instruction::ShiftPhase(ShiftPhase { .. })
+            | Instruction::SwapPhases(SwapPhases { .. }) => InstructionRole::RFControl,
+            Instruction::Arithmetic(Arithmetic { .. })
+            | Instruction::Move(Move { .. })
+            | Instruction::Exchange(Exchange { .. })
+            | Instruction::Load(Load { .. })
             | Instruction::Store { .. } => InstructionRole::ClassicalCompute,
-            Instruction::Halt
-            | Instruction::Jump { .. }
-            | Instruction::JumpWhen { .. }
-            | Instruction::JumpUnless { .. } => InstructionRole::ControlFlow,
+            Instruction::Halt(_)
+            | Instruction::Jump(Jump { .. })
+            | Instruction::JumpWhen(JumpWhen { .. })
+            | Instruction::JumpUnless(JumpUnless { .. }) => InstructionRole::ControlFlow,
         }
     }
 }
@@ -460,14 +558,13 @@ pub fn get_string_parameter_string(parameters: &[String]) -> String {
 
 impl fmt::Display for Instruction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Instruction::*;
         match self {
-            Arithmetic {
+            Instruction::Arithmetic(Arithmetic {
                 operator,
                 destination,
                 source,
-            } => write!(f, "{} {} {}", operator, destination, source),
-            CalibrationDefinition(calibration) => {
+            }) => write!(f, "{} {} {}", operator, destination, source),
+            Instruction::CalibrationDefinition(CalibrationDefinition(calibration)) => {
                 let parameter_str = get_expression_parameter_string(&calibration.parameters);
                 write!(
                     f,
@@ -481,23 +578,23 @@ impl fmt::Display for Instruction {
                 }
                 Ok(())
             }
-            Capture {
+            Instruction::Capture(Capture {
                 blocking,
                 frame,
                 waveform,
                 memory_reference,
-            } => {
+            }) => {
                 if !blocking {
                     write!(f, "NONBLOCKING ")?;
                 }
                 write!(f, "CAPTURE {} {} {}", frame, waveform, memory_reference)
             }
-            CircuitDefinition {
+            Instruction::CircuitDefinition(CircuitDefinition {
                 name,
                 parameters,
                 qubit_variables,
                 instructions,
-            } => {
+            }) => {
                 let mut parameter_str: String = parameters
                     .iter()
                     .map(|p| format!("%{}", p))
@@ -516,11 +613,11 @@ impl fmt::Display for Instruction {
                 }
                 Ok(())
             }
-            Declaration {
+            Instruction::Declaration(Declaration {
                 name,
                 size,
                 sharing,
-            } => {
+            }) => {
                 write!(f, "DECLARE {} {}", name, size)?;
                 match sharing {
                     Some(shared) => write!(f, "SHARING {}", shared)?,
@@ -528,28 +625,28 @@ impl fmt::Display for Instruction {
                 }
                 Ok(())
             }
-            Delay {
+            Instruction::Delay(Delay {
                 qubits,
                 frame_names,
                 duration,
-            } => {
+            }) => {
                 write!(f, "DELAY {}", format_qubits(qubits))?;
                 for frame_name in frame_names {
                     write!(f, " \"{}\"", frame_name)?;
                 }
                 write!(f, " {}", duration)
             }
-            Fence { qubits } => {
+            Instruction::Fence(Fence { qubits }) => {
                 if qubits.is_empty() {
                     write!(f, "FENCE")
                 } else {
                     write!(f, "FENCE {}", format_qubits(qubits))
                 }
             }
-            FrameDefinition {
+            Instruction::FrameDefinition(FrameDefinition {
                 identifier,
                 attributes,
-            } => write!(
+            }) => write!(
                 f,
                 "DEFFRAME {}:{}",
                 identifier,
@@ -558,12 +655,12 @@ impl fmt::Display for Instruction {
                     .map(|(k, v)| format!("\n\t{}: {}", k, v))
                     .collect::<String>()
             ),
-            Gate {
+            Instruction::Gate(Gate {
                 name,
                 parameters,
                 qubits,
                 modifiers,
-            } => {
+            }) => {
                 let parameter_str = get_expression_parameter_string(parameters);
 
                 let qubit_str = format_qubits(qubits);
@@ -574,12 +671,12 @@ impl fmt::Display for Instruction {
                     .join("");
                 write!(f, "{}{}{} {}", modifier_str, name, parameter_str, qubit_str)
             }
-            GateDefinition {
+            Instruction::GateDefinition(GateDefinition {
                 name,
                 parameters,
                 matrix,
                 r#type,
-            } => {
+            }) => {
                 let parameter_str: String = parameters.iter().map(|p| p.to_string()).collect();
                 writeln!(f, "DEFGATE {}{} AS {}:", name, parameter_str, r#type)?;
                 for row in matrix {
@@ -594,11 +691,11 @@ impl fmt::Display for Instruction {
                 }
                 Ok(())
             }
-            MeasureCalibrationDefinition {
+            Instruction::MeasureCalibrationDefinition(MeasureCalibrationDefinition {
                 qubit,
                 parameter,
                 instructions,
-            } => {
+            }) => {
                 write!(f, "DEFCAL MEASURE")?;
                 match qubit {
                     Some(qubit) => {
@@ -614,72 +711,84 @@ impl fmt::Display for Instruction {
                     format_instructions(instructions)
                 )
             }
-            Measurement { qubit, target } => match target {
+            Instruction::Measurement(Measurement { qubit, target }) => match target {
                 Some(reference) => write!(f, "MEASURE {} {}", qubit, reference),
                 None => write!(f, "MEASURE {}", qubit),
             },
-            Move {
+            Instruction::Move(Move {
                 destination,
                 source,
-            } => write!(f, "MOVE {} {}", destination, source),
-            Exchange { left, right } => write!(f, "EXCHANGE {} {}", left, right),
-            Load {
+            }) => write!(f, "MOVE {} {}", destination, source),
+            Instruction::Exchange(Exchange { left, right }) => {
+                write!(f, "EXCHANGE {} {}", left, right)
+            }
+            Instruction::Load(Load {
                 destination,
                 source,
                 offset,
-            } => {
+            }) => {
                 write!(f, "LOAD {} {} {}", destination, source, offset)
             }
-            Store {
+            Instruction::Store(Store {
                 destination,
                 offset,
                 source,
-            } => {
+            }) => {
                 write!(f, "STORE {} {} {}", destination, offset, source)
             }
-            Pulse {
+            Instruction::Pulse(Pulse {
                 blocking,
                 frame,
                 waveform,
-            } => {
+            }) => {
                 if !blocking {
                     write!(f, "NONBLOCKING ")?;
                 }
                 write!(f, "PULSE {} {}", frame, waveform)
             }
-            Pragma {
+            Instruction::Pragma(Pragma {
                 name,
                 arguments,
                 data,
-            } => match data {
+            }) => match data {
                 // FIXME: Handle empty argument lists
                 Some(data) => write!(f, "PRAGMA {} {} {}", name, arguments.join(" "), data),
                 None => write!(f, "PRAGMA {} {}", name, arguments.join(" ")),
             },
-            RawCapture {
+            Instruction::RawCapture(RawCapture {
                 blocking,
                 frame,
                 duration,
                 memory_reference,
-            } => {
+            }) => {
                 if !blocking {
                     write!(f, "NONBLOCKING ")?;
                 }
                 write!(f, "RAW-CAPTURE {} {} {}", frame, duration, memory_reference)
             }
-            Reset { qubit } => match qubit {
+            Instruction::Reset(Reset { qubit }) => match qubit {
                 Some(qubit) => write!(f, "RESET {}", qubit),
                 None => write!(f, "RESET"),
             },
-            SetFrequency { frame, frequency } => write!(f, "SET-FREQUENCY {} {}", frame, frequency),
-            SetPhase { frame, phase } => write!(f, "SET-PHASE {} {}", frame, phase),
-            SetScale { frame, scale } => write!(f, "SET-SCALE {} {}", frame, scale),
-            ShiftFrequency { frame, frequency } => {
+            Instruction::SetFrequency(SetFrequency { frame, frequency }) => {
+                write!(f, "SET-FREQUENCY {} {}", frame, frequency)
+            }
+            Instruction::SetPhase(SetPhase { frame, phase }) => {
+                write!(f, "SET-PHASE {} {}", frame, phase)
+            }
+            Instruction::SetScale(SetScale { frame, scale }) => {
+                write!(f, "SET-SCALE {} {}", frame, scale)
+            }
+            Instruction::ShiftFrequency(ShiftFrequency { frame, frequency }) => {
                 write!(f, "SHIFT-FREQUENCY {} {}", frame, frequency)
             }
-            ShiftPhase { frame, phase } => write!(f, "SHIFT-PHASE {} {}", frame, phase),
-            SwapPhases { frame_1, frame_2 } => write!(f, "SWAP-PHASES {} {}", frame_1, frame_2),
-            WaveformDefinition { name, definition } => write!(
+            Instruction::ShiftPhase(ShiftPhase { frame, phase }) => {
+                write!(f, "SHIFT-PHASE {} {}", frame, phase)
+            }
+            Instruction::SwapPhases(SwapPhases { frame_1, frame_2 }) => {
+                write!(f, "SWAP-PHASES {} {}", frame_1, frame_2)
+            }
+            Instruction::WaveformDefinition(WaveformDefinition { name, definition }) => write!(
                 f,
                 "DEFWAVEFORM {}{} {}:\n\t{}",
                 name,
@@ -692,11 +801,15 @@ impl fmt::Display for Instruction {
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
-            Halt => write!(f, "HALT"),
-            Jump { target } => write!(f, "JUMP @{}", target),
-            JumpUnless { condition, target } => write!(f, "JUMP-UNLESS @{} {}", target, condition),
-            JumpWhen { condition, target } => write!(f, "JUMP-WHEN @{} {}", target, condition),
-            Label(label) => write!(f, "LABEL @{}", label),
+            Instruction::Halt(Halt { .. }) => write!(f, "HALT"),
+            Instruction::Jump(Jump { target }) => write!(f, "JUMP @{}", target),
+            Instruction::JumpUnless(JumpUnless { condition, target }) => {
+                write!(f, "JUMP-UNLESS @{} {}", target, condition)
+            }
+            Instruction::JumpWhen(JumpWhen { condition, target }) => {
+                write!(f, "JUMP-WHEN @{} {}", target, condition)
+            }
+            Instruction::Label(Label(label)) => write!(f, "LABEL @{}", label),
         }
     }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -365,9 +365,6 @@ pub struct Arithmetic {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Halt;
-
-#[derive(Clone, Debug, PartialEq)]
 pub struct Label(pub String);
 
 #[derive(Clone, Debug, PartialEq)]
@@ -438,7 +435,7 @@ pub enum Instruction {
     SwapPhases(SwapPhases),
     WaveformDefinition(WaveformDefinition),
     Arithmetic(Arithmetic),
-    Halt(Halt),
+    Halt,
     Label(Label),
     Move(Move),
     Exchange(Exchange),
@@ -461,39 +458,37 @@ impl From<&Instruction> for InstructionRole {
     fn from(instruction: &Instruction) -> Self {
         match instruction {
             Instruction::CalibrationDefinition(_)
-            | Instruction::CircuitDefinition(CircuitDefinition { .. })
-            | Instruction::Declaration(Declaration { .. })
-            | Instruction::FrameDefinition(FrameDefinition { .. })
-            | Instruction::Gate(Gate { .. })
-            | Instruction::GateDefinition(GateDefinition { .. })
-            | Instruction::Label(Label(_))
-            | Instruction::MeasureCalibrationDefinition(MeasureCalibrationDefinition { .. })
-            | Instruction::Measurement(Measurement { .. })
-            | Instruction::Pragma(Pragma { .. })
-            | Instruction::WaveformDefinition(WaveformDefinition { .. }) => {
-                InstructionRole::ProgramComposition
-            }
-            Instruction::Reset(Reset { .. })
-            | Instruction::Capture(Capture { .. })
-            | Instruction::Delay(Delay { .. })
-            | Instruction::Fence(Fence { .. })
-            | Instruction::Pulse(Pulse { .. })
-            | Instruction::RawCapture(RawCapture { .. })
-            | Instruction::SetFrequency(SetFrequency { .. })
-            | Instruction::SetPhase(SetPhase { .. })
-            | Instruction::SetScale(SetScale { .. })
-            | Instruction::ShiftFrequency(ShiftFrequency { .. })
-            | Instruction::ShiftPhase(ShiftPhase { .. })
-            | Instruction::SwapPhases(SwapPhases { .. }) => InstructionRole::RFControl,
-            Instruction::Arithmetic(Arithmetic { .. })
-            | Instruction::Move(Move { .. })
-            | Instruction::Exchange(Exchange { .. })
-            | Instruction::Load(Load { .. })
-            | Instruction::Store { .. } => InstructionRole::ClassicalCompute,
-            Instruction::Halt(_)
-            | Instruction::Jump(Jump { .. })
-            | Instruction::JumpWhen(JumpWhen { .. })
-            | Instruction::JumpUnless(JumpUnless { .. }) => InstructionRole::ControlFlow,
+            | Instruction::CircuitDefinition(_)
+            | Instruction::Declaration(_)
+            | Instruction::FrameDefinition(_)
+            | Instruction::Gate(_)
+            | Instruction::GateDefinition(_)
+            | Instruction::Label(_)
+            | Instruction::MeasureCalibrationDefinition(_)
+            | Instruction::Measurement(_)
+            | Instruction::Pragma(_)
+            | Instruction::WaveformDefinition(_) => InstructionRole::ProgramComposition,
+            Instruction::Reset(_)
+            | Instruction::Capture(_)
+            | Instruction::Delay(_)
+            | Instruction::Fence(_)
+            | Instruction::Pulse(_)
+            | Instruction::RawCapture(_)
+            | Instruction::SetFrequency(_)
+            | Instruction::SetPhase(_)
+            | Instruction::SetScale(_)
+            | Instruction::ShiftFrequency(_)
+            | Instruction::ShiftPhase(_)
+            | Instruction::SwapPhases(_) => InstructionRole::RFControl,
+            Instruction::Arithmetic(_)
+            | Instruction::Move(_)
+            | Instruction::Exchange(_)
+            | Instruction::Load(_)
+            | Instruction::Store(_) => InstructionRole::ClassicalCompute,
+            Instruction::Halt
+            | Instruction::Jump(_)
+            | Instruction::JumpWhen(_)
+            | Instruction::JumpUnless(_) => InstructionRole::ControlFlow,
         }
     }
 }
@@ -798,7 +793,7 @@ impl fmt::Display for Instruction {
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
-            Instruction::Halt(Halt { .. }) => write!(f, "HALT"),
+            Instruction::Halt => write!(f, "HALT"),
             Instruction::Jump(Jump { target }) => write!(f, "JUMP @{}", target),
             Instruction::JumpUnless(JumpUnless { condition, target }) => {
                 write!(f, "JUMP-UNLESS @{} {}", target, condition)

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -31,7 +31,7 @@ use super::{
 use crate::instruction::{
     Arithmetic, CalibrationDefinition, Capture, CircuitDefinition, Declaration, Delay, Exchange,
     Fence, FrameDefinition, Jump, JumpUnless, JumpWhen, Label, Load, Measurement, Move, Pragma,
-    Pulse, RawCapture, Store, WaveformDefinition,
+    Pulse, RawCapture, SetFrequency, SetScale, ShiftFrequency, Store, WaveformDefinition,
 };
 use crate::parser::common::parse_variable_qubit;
 use crate::parser::instruction::parse_block;
@@ -365,7 +365,10 @@ pub fn parse_set_frequency(input: ParserInput) -> ParserResult<Instruction> {
     let (input, frame) = parse_frame_identifier(input)?;
     let (input, frequency) = parse_expression(input)?;
 
-    Ok((input, Instruction::SetFrequency { frame, frequency }))
+    Ok((
+        input,
+        Instruction::SetFrequency(SetFrequency { frame, frequency }),
+    ))
 }
 
 /// Parse the contents of a `SET-PHASE` instruction.
@@ -381,7 +384,7 @@ pub fn parse_set_scale(input: ParserInput) -> ParserResult<Instruction> {
     let (input, frame) = parse_frame_identifier(input)?;
     let (input, scale) = parse_expression(input)?;
 
-    Ok((input, Instruction::SetScale { frame, scale }))
+    Ok((input, Instruction::SetScale(SetScale { frame, scale })))
 }
 
 /// Parse the contents of a `SHIFT-FREQUENCY` instruction.
@@ -389,7 +392,10 @@ pub fn parse_shift_frequency(input: ParserInput) -> ParserResult<Instruction> {
     let (input, frame) = parse_frame_identifier(input)?;
     let (input, frequency) = parse_expression(input)?;
 
-    Ok((input, Instruction::ShiftFrequency { frame, frequency }))
+    Ok((
+        input,
+        Instruction::ShiftFrequency(ShiftFrequency { frame, frequency }),
+    ))
 }
 
 /// Parse the contents of a `SHIFT-PHASE` instruction.

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -28,6 +28,11 @@ use super::{
     expression::parse_expression,
     instruction, ParserInput, ParserResult,
 };
+use crate::instruction::{
+    Arithmetic, CalibrationDefinition, Capture, CircuitDefinition, Declaration, Delay, Exchange,
+    Fence, FrameDefinition, Jump, JumpUnless, JumpWhen, Label, Load, Measurement, Move, Pragma,
+    Pulse, RawCapture, Store, WaveformDefinition,
+};
 use crate::parser::common::parse_variable_qubit;
 use crate::parser::instruction::parse_block;
 use crate::{
@@ -50,11 +55,11 @@ pub fn parse_arithmetic(
     let (input, source) = common::parse_arithmetic_operand(input)?;
     Ok((
         input,
-        Instruction::Arithmetic {
+        Instruction::Arithmetic(Arithmetic {
             operator,
             destination,
             source,
-        },
+        }),
     ))
 }
 
@@ -64,11 +69,11 @@ pub fn parse_declare<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction
     let (input, size) = common::parse_vector(input)?;
     Ok((
         input,
-        Instruction::Declaration {
+        Instruction::Declaration(Declaration {
             name,
             sharing: None,
             size,
-        },
+        }),
     ))
 }
 
@@ -83,12 +88,12 @@ pub fn parse_capture(input: ParserInput, blocking: bool) -> ParserResult<Instruc
 
     Ok((
         input,
-        Instruction::Capture {
+        Instruction::Capture(Capture {
             blocking,
             frame,
-            waveform,
             memory_reference,
-        },
+            waveform,
+        }),
     ))
 }
 
@@ -107,13 +112,13 @@ pub fn parse_defcal<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction>
     let (input, instructions) = instruction::parse_block(input)?;
     Ok((
         input,
-        Instruction::CalibrationDefinition(Calibration {
+        Instruction::CalibrationDefinition(CalibrationDefinition(Calibration {
             instructions,
             modifiers,
             name,
             parameters,
             qubits,
-        }),
+        })),
     ))
 }
 
@@ -126,10 +131,10 @@ pub fn parse_defframe<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instructio
 
     Ok((
         input,
-        Instruction::FrameDefinition {
+        Instruction::FrameDefinition(FrameDefinition {
             identifier,
             attributes,
-        },
+        }),
     ))
 }
 
@@ -162,14 +167,14 @@ pub fn parse_defwaveform<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruc
 
     Ok((
         input,
-        Instruction::WaveformDefinition {
+        Instruction::WaveformDefinition(WaveformDefinition {
             name,
             definition: Waveform {
                 matrix,
                 parameters,
                 sample_rate,
             },
-        },
+        }),
     ))
 }
 
@@ -187,12 +192,12 @@ pub fn parse_defcircuit<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruct
 
     Ok((
         input,
-        Instruction::CircuitDefinition {
+        Instruction::CircuitDefinition(CircuitDefinition {
             name,
             parameters,
             qubit_variables,
             instructions,
-        },
+        }),
     ))
 }
 
@@ -204,11 +209,11 @@ pub fn parse_delay<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> 
 
     Ok((
         input,
-        Instruction::Delay {
+        Instruction::Delay(Delay {
+            duration,
             frame_names,
             qubits,
-            duration,
-        },
+        }),
     ))
 }
 
@@ -219,10 +224,10 @@ pub fn parse_exchange(input: ParserInput) -> ParserResult<Instruction> {
 
     Ok((
         input,
-        Instruction::Exchange {
+        Instruction::Exchange(Exchange {
             left: ArithmeticOperand::MemoryReference(left),
             right: ArithmeticOperand::MemoryReference(right),
-        },
+        }),
     ))
 }
 
@@ -230,33 +235,36 @@ pub fn parse_exchange(input: ParserInput) -> ParserResult<Instruction> {
 pub fn parse_fence(input: ParserInput) -> ParserResult<Instruction> {
     let (input, qubits) = many0(parse_qubit)(input)?;
 
-    Ok((input, Instruction::Fence { qubits }))
+    Ok((input, Instruction::Fence(Fence { qubits })))
 }
 
 /// Parse the contents of a `JUMP` instruction.
 pub fn parse_jump<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
     let (input, target) = token!(Label(v))(input)?;
-    Ok((input, Instruction::Jump { target }))
+    Ok((input, Instruction::Jump(Jump { target })))
 }
 
 /// Parse the contents of a `JUMP-WHEN` instruction.
 pub fn parse_jump_when<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
     let (input, target) = token!(Label(v))(input)?;
     let (input, condition) = common::parse_memory_reference(input)?;
-    Ok((input, Instruction::JumpWhen { condition, target }))
+    Ok((input, Instruction::JumpWhen(JumpWhen { target, condition })))
 }
 
 /// Parse the contents of a `JUMP-UNLESS` instruction.
 pub fn parse_jump_unless<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
     let (input, target) = token!(Label(v))(input)?;
     let (input, condition) = common::parse_memory_reference(input)?;
-    Ok((input, Instruction::JumpUnless { condition, target }))
+    Ok((
+        input,
+        Instruction::JumpUnless(JumpUnless { target, condition }),
+    ))
 }
 
 /// Parse the contents of a `DECLARE` instruction.
 pub fn parse_label<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
     let (input, name) = token!(Label(v))(input)?;
-    Ok((input, Instruction::Label(name)))
+    Ok((input, Instruction::Label(Label(name))))
 }
 
 /// Parse the contents of a `MOVE` instruction.
@@ -265,10 +273,10 @@ pub fn parse_move(input: ParserInput) -> ParserResult<Instruction> {
     let (input, source) = common::parse_arithmetic_operand(input)?;
     Ok((
         input,
-        Instruction::Move {
+        Instruction::Move(Move {
             destination,
             source,
-        },
+        }),
     ))
 }
 
@@ -280,11 +288,11 @@ pub fn parse_load<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
 
     Ok((
         input,
-        Instruction::Load {
+        Instruction::Load(Load {
             destination,
             source,
             offset,
-        },
+        }),
     ))
 }
 
@@ -296,11 +304,11 @@ pub fn parse_store<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> 
 
     Ok((
         input,
-        Instruction::Store {
+        Instruction::Store(Store {
             destination,
-            source,
             offset,
-        },
+            source,
+        }),
     ))
 }
 
@@ -312,11 +320,11 @@ pub fn parse_pragma<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction>
     let (input, data) = opt(token!(String(v)))(input)?;
     Ok((
         input,
-        Instruction::Pragma {
+        Instruction::Pragma(Pragma {
             name: pragma_type,
             arguments,
             data,
-        },
+        }),
     ))
 }
 
@@ -327,11 +335,11 @@ pub fn parse_pulse(input: ParserInput, blocking: bool) -> ParserResult<Instructi
 
     Ok((
         input,
-        Instruction::Pulse {
+        Instruction::Pulse(Pulse {
             blocking,
             frame,
             waveform,
-        },
+        }),
     ))
 }
 
@@ -343,12 +351,12 @@ pub fn parse_raw_capture(input: ParserInput, blocking: bool) -> ParserResult<Ins
 
     Ok((
         input,
-        Instruction::RawCapture {
+        Instruction::RawCapture(RawCapture {
             blocking,
             frame,
             duration,
             memory_reference,
-        },
+        }),
     ))
 }
 
@@ -400,14 +408,20 @@ pub fn parse_measurement(input: ParserInput) -> ParserResult<Instruction> {
         Err(_) => (input, None),
     };
 
-    Ok((input, Instruction::Measurement { qubit, target }))
+    Ok((
+        input,
+        Instruction::Measurement(Measurement { qubit, target }),
+    ))
 }
 
 #[cfg(test)]
 mod tests {
     use crate::parser::lexer::lex;
     use crate::{
-        instruction::{Instruction, MemoryReference, Qubit, ScalarType, Vector},
+        instruction::{
+            CircuitDefinition, Declaration, Gate, Instruction, Measurement, MemoryReference,
+            Pragma, Qubit, ScalarType, Vector,
+        },
         make_test,
     };
 
@@ -418,85 +432,85 @@ mod tests {
         declare_instruction_length_1,
         parse_declare,
         "ro BIT",
-        Instruction::Declaration {
+        Instruction::Declaration(Declaration {
             name: "ro".to_owned(),
             sharing: None,
             size: Vector {
                 data_type: ScalarType::Bit,
                 length: 1
             }
-        }
+        })
     );
 
     make_test!(
         declare_instruction_length_n,
         parse_declare,
         "ro INTEGER[5]",
-        Instruction::Declaration {
+        Instruction::Declaration(Declaration {
             name: "ro".to_owned(),
             sharing: None,
             size: Vector {
                 data_type: ScalarType::Integer,
                 length: 5
             }
-        }
+        })
     );
 
     make_test!(
         measure_into_register,
         parse_measurement,
         "0 ro[0]",
-        Instruction::Measurement {
+        Instruction::Measurement(Measurement {
             qubit: Qubit::Fixed(0),
             target: Some(MemoryReference {
                 name: String::from("ro"),
                 index: 0
             })
-        }
+        })
     );
 
     make_test!(
         measure_discard,
         parse_measurement,
         "0",
-        Instruction::Measurement {
+        Instruction::Measurement(Measurement {
             qubit: Qubit::Fixed(0),
             target: None
-        }
+        })
     );
 
     make_test!(
         measure_named_qubit,
         parse_measurement,
         "q0 ro[0]",
-        Instruction::Measurement {
+        Instruction::Measurement(Measurement {
             qubit: Qubit::Variable(String::from("q0")),
             target: Some(MemoryReference {
                 name: String::from("ro"),
                 index: 0
             })
-        }
+        })
     );
 
     make_test!(
         measure_named_qubit_discard,
         parse_measurement,
         "q0",
-        Instruction::Measurement {
+        Instruction::Measurement(Measurement {
             qubit: Qubit::Variable(String::from("q0")),
             target: None
-        }
+        })
     );
 
     make_test!(
         pragma_inline_json,
         parse_pragma,
         "FILTER-NODE q35_unclassified \"{'module':'lodgepole.filters.io','filter_type':'DataBuffer','source':'q35_ro_rx/filter','publish':true,'params':{},'_type':'FilterNode'}\"",
-        Instruction::Pragma {
+        Instruction::Pragma(Pragma {
             name: "FILTER-NODE".to_owned(),
             arguments: vec!["q35_unclassified".to_owned()],
             data: Some("{'module':'lodgepole.filters.io','filter_type':'DataBuffer','source':'q35_ro_rx/filter','publish':true,'params':{},'_type':'FilterNode'}".to_owned())
-        }
+        })
     );
 
     make_test!(
@@ -505,18 +519,18 @@ mod tests {
         "BELL a b:
     H a
     CNOT a b",
-        Instruction::CircuitDefinition {
+        Instruction::CircuitDefinition(CircuitDefinition {
             name: "BELL".to_owned(),
             parameters: vec![],
             qubit_variables: vec!["a".to_owned(), "b".to_owned()],
             instructions: vec![
-                Instruction::Gate {
+                Instruction::Gate(Gate {
                     name: "H".to_owned(),
                     parameters: vec![],
                     qubits: vec![Qubit::Variable("a".to_owned())],
                     modifiers: vec![],
-                },
-                Instruction::Gate {
+                }),
+                Instruction::Gate(Gate {
                     name: "CNOT".to_owned(),
                     parameters: vec![],
                     qubits: vec![
@@ -524,9 +538,9 @@ mod tests {
                         Qubit::Variable("b".to_owned())
                     ],
                     modifiers: vec![],
-                }
+                })
             ]
-        }
+        })
     );
 
     make_test!(
@@ -537,30 +551,30 @@ mod tests {
     RX(%a) a
     RZ(%a) a
     CNOT a b",
-        Instruction::CircuitDefinition {
+        Instruction::CircuitDefinition(CircuitDefinition {
             name: "BELL".to_owned(),
             parameters: vec!["a".to_owned()],
             qubit_variables: vec!["a".to_owned(), "b".to_owned()],
             instructions: vec![
-                Instruction::Gate {
+                Instruction::Gate(Gate {
                     name: "RZ".to_owned(),
                     parameters: vec![Expression::Variable("a".to_owned())],
                     qubits: vec![Qubit::Variable("a".to_owned())],
                     modifiers: vec![],
-                },
-                Instruction::Gate {
+                }),
+                Instruction::Gate(Gate {
                     name: "RX".to_owned(),
                     parameters: vec![Expression::Variable("a".to_owned())],
                     qubits: vec![Qubit::Variable("a".to_owned())],
                     modifiers: vec![],
-                },
-                Instruction::Gate {
+                }),
+                Instruction::Gate(Gate {
                     name: "RZ".to_owned(),
                     parameters: vec![Expression::Variable("a".to_owned())],
                     qubits: vec![Qubit::Variable("a".to_owned())],
                     modifiers: vec![],
-                },
-                Instruction::Gate {
+                }),
+                Instruction::Gate(Gate {
                     name: "CNOT".to_owned(),
                     parameters: vec![],
                     qubits: vec![
@@ -568,8 +582,8 @@ mod tests {
                         Qubit::Variable("b".to_owned())
                     ],
                     modifiers: vec![],
-                }
+                })
             ]
-        }
+        })
     );
 }

--- a/src/parser/gate.rs
+++ b/src/parser/gate.rs
@@ -22,6 +22,7 @@ use super::{
     expression::parse_expression,
     ParserInput, ParserResult,
 };
+use crate::instruction::Gate;
 
 /// Parse a gate instruction.
 pub fn parse_gate<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
@@ -36,12 +37,12 @@ pub fn parse_gate<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
     let (input, qubits) = many0(common::parse_qubit)(input)?;
     Ok((
         input,
-        Instruction::Gate {
+        Instruction::Gate(Gate {
             name,
-            modifiers,
             parameters,
             qubits,
-        },
+            modifiers,
+        }),
     ))
 }
 
@@ -49,7 +50,7 @@ pub fn parse_gate<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
 mod test {
     use super::parse_gate;
     use crate::expression::Expression;
-    use crate::instruction::{GateModifier, Instruction, Qubit};
+    use crate::instruction::{Gate, GateModifier, Instruction, Qubit};
     use crate::make_test;
     use crate::parser::lexer::lex;
 
@@ -57,11 +58,11 @@ mod test {
         test_modifiers,
         parse_gate,
         "DAGGER CONTROLLED RX(pi) 0 1",
-        Instruction::Gate {
+        Instruction::Gate(Gate {
             name: "RX".to_string(),
             parameters: vec![Expression::PiConstant],
             qubits: vec![Qubit::Fixed(0), Qubit::Fixed(1)],
             modifiers: vec![GateModifier::Dagger, GateModifier::Controlled],
-        }
+        })
     );
 }

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -19,7 +19,6 @@ use nom::{
     sequence::{delimited, preceded},
 };
 
-use crate::instruction::Halt;
 use crate::{
     instruction::{ArithmeticOperator, Instruction},
     token,
@@ -60,7 +59,7 @@ pub fn parse_instruction(input: ParserInput) -> ParserResult<Instruction> {
                 Command::Fence => command::parse_fence(remainder),
                 // Command::GE => {}
                 // Command::GT => {}
-                Command::Halt => Ok((remainder, Instruction::Halt(Halt {}))),
+                Command::Halt => Ok((remainder, Instruction::Halt)),
                 // Command::Include => {}
                 // Command::Ior => {}
                 Command::Jump => command::parse_jump(remainder),

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -161,7 +161,7 @@ mod tests {
     use crate::{instruction::Calibration, parser::lexer::lex};
 
     use super::parse_instructions;
-    use crate::instruction::Label;
+    use crate::instruction::{Label, SetFrequency, SetScale, ShiftFrequency};
 
     make_test!(
         semicolons_are_newlines,
@@ -503,14 +503,14 @@ mod tests {
         let tokens = lex(r#"SET-SCALE 0 "rf" 1.0; SET-SCALE 0 1 "rf" theta"#);
         let (remainder, parsed) = parse_instructions(&tokens).unwrap();
         let expected = vec![
-            Instruction::SetScale {
+            Instruction::SetScale(SetScale {
                 frame: FrameIdentifier {
                     name: String::from("rf"),
                     qubits: vec![Qubit::Fixed(0)],
                 },
                 scale: Expression::Number(real!(1.0)),
-            },
-            Instruction::SetScale {
+            }),
+            Instruction::SetScale(SetScale {
                 frame: FrameIdentifier {
                     name: String::from("rf"),
                     qubits: vec![Qubit::Fixed(0), Qubit::Fixed(1)],
@@ -519,7 +519,7 @@ mod tests {
                     name: String::from("theta"),
                     index: 0,
                 }),
-            },
+            }),
         ];
         assert_eq!(remainder.len(), 0);
         assert_eq!(parsed, expected);
@@ -530,14 +530,14 @@ mod tests {
         let tokens = lex(r#"SET-FREQUENCY 0 "rf" 1.0; SET-FREQUENCY 0 1 "rf" theta"#);
         let (remainder, parsed) = parse_instructions(&tokens).unwrap();
         let expected = vec![
-            Instruction::SetFrequency {
+            Instruction::SetFrequency(SetFrequency {
                 frame: FrameIdentifier {
                     name: String::from("rf"),
                     qubits: vec![Qubit::Fixed(0)],
                 },
                 frequency: Expression::Number(real!(1.0)),
-            },
-            Instruction::SetFrequency {
+            }),
+            Instruction::SetFrequency(SetFrequency {
                 frame: FrameIdentifier {
                     name: String::from("rf"),
                     qubits: vec![Qubit::Fixed(0), Qubit::Fixed(1)],
@@ -546,7 +546,7 @@ mod tests {
                     name: String::from("theta"),
                     index: 0,
                 }),
-            },
+            }),
         ];
         assert_eq!(remainder.len(), 0);
         assert_eq!(parsed, expected);
@@ -557,14 +557,14 @@ mod tests {
         let tokens = lex(r#"SHIFT-FREQUENCY 0 "rf" 1.0; SHIFT-FREQUENCY 0 1 "rf" theta"#);
         let (remainder, parsed) = parse_instructions(&tokens).unwrap();
         let expected = vec![
-            Instruction::ShiftFrequency {
+            Instruction::ShiftFrequency(ShiftFrequency {
                 frame: FrameIdentifier {
                     name: String::from("rf"),
                     qubits: vec![Qubit::Fixed(0)],
                 },
                 frequency: Expression::Number(real!(1.0)),
-            },
-            Instruction::ShiftFrequency {
+            }),
+            Instruction::ShiftFrequency(ShiftFrequency {
                 frame: FrameIdentifier {
                     name: String::from("rf"),
                     qubits: vec![Qubit::Fixed(0), Qubit::Fixed(1)],
@@ -573,7 +573,7 @@ mod tests {
                     name: String::from("theta"),
                     index: 0,
                 }),
-            },
+            }),
         ];
         assert_eq!(remainder.len(), 0);
         assert_eq!(parsed, expected);

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -15,6 +15,7 @@
  **/
 use std::collections::HashMap;
 
+use crate::instruction::{CalibrationDefinition, Gate};
 use crate::{
     expression::Expression,
     instruction::{Calibration, GateModifier, Instruction, Qubit},
@@ -57,12 +58,12 @@ impl CalibrationSet {
     /// Given an instruction, return the instructions to which it is expanded if there is a match.
     pub fn expand(&self, instruction: &Instruction) -> Option<Vec<Instruction>> {
         match instruction {
-            Instruction::Gate {
+            Instruction::Gate(Gate {
                 name,
                 modifiers,
                 parameters,
                 qubits,
-            } => {
+            }) => {
                 let matching_calibration =
                     self.get_match_for_gate(modifiers, name, parameters, qubits);
 
@@ -78,7 +79,7 @@ impl CalibrationSet {
                         let mut instructions = calibration.instructions.clone();
 
                         for instruction in instructions.iter_mut() {
-                            if let Instruction::Gate { qubits, .. } = instruction {
+                            if let Instruction::Gate(Gate { qubits, .. }) = instruction {
                                 // Swap all qubits for their concrete implementations
                                 for qubit in qubits {
                                     match qubit {
@@ -213,7 +214,7 @@ impl CalibrationSet {
     pub fn to_instructions(&self) -> Vec<Instruction> {
         self.calibrations
             .iter()
-            .map(|c| Instruction::CalibrationDefinition(c.clone()))
+            .map(|c| Instruction::CalibrationDefinition(CalibrationDefinition(c.clone())))
             .collect()
     }
 }

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -15,10 +15,9 @@
  **/
 use std::collections::HashMap;
 
-use crate::instruction::{CalibrationDefinition, Gate};
 use crate::{
     expression::Expression,
-    instruction::{Calibration, GateModifier, Instruction, Qubit},
+    instruction::{Calibration, Gate, GateModifier, Instruction, Qubit},
 };
 
 /// A collection of Quil calibrations (`DEFCAL` instructions) with utility methods.
@@ -214,15 +213,16 @@ impl CalibrationSet {
     pub fn to_instructions(&self) -> Vec<Instruction> {
         self.calibrations
             .iter()
-            .map(|c| Instruction::CalibrationDefinition(CalibrationDefinition(c.clone())))
+            .map(|c| Instruction::CalibrationDefinition(c.clone()))
             .collect()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::program::Program;
     use std::str::FromStr;
+
+    use crate::program::Program;
 
     #[test]
     fn test_expansion() {

--- a/src/program/frame.rs
+++ b/src/program/frame.rs
@@ -15,7 +15,7 @@
  **/
 use std::collections::{HashMap, HashSet};
 
-use crate::instruction::{FrameAttributes, FrameIdentifier, Instruction, Qubit};
+use crate::instruction::{FrameAttributes, FrameDefinition, FrameIdentifier, Instruction, Qubit};
 
 /// A collection of Quil frames (`DEFFRAME` instructions) with utility methods.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -78,9 +78,11 @@ impl FrameSet {
     pub fn to_instructions(&self) -> Vec<Instruction> {
         self.frames
             .iter()
-            .map(|(identifier, attributes)| Instruction::FrameDefinition {
-                identifier: identifier.clone(),
-                attributes: attributes.clone(),
+            .map(|(identifier, attributes)| {
+                Instruction::FrameDefinition(FrameDefinition {
+                    identifier: identifier.clone(),
+                    attributes: attributes.clone(),
+                })
             })
             .collect()
     }

--- a/src/program/memory.rs
+++ b/src/program/memory.rs
@@ -1,5 +1,12 @@
 use std::collections::HashSet;
 
+use crate::instruction::{
+    Arithmetic, CalibrationDefinition, Capture, CircuitDefinition, Declaration, Delay, Exchange,
+    Fence, FrameDefinition, Gate, GateDefinition, Jump, JumpUnless, JumpWhen, Label, Load,
+    MeasureCalibrationDefinition, Measurement, Move, Pragma, Pulse, RawCapture, Reset,
+    SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, SwapPhases,
+    WaveformDefinition,
+};
 /**
  * Copyright 2021 Rigetti Computing
  *
@@ -87,20 +94,20 @@ impl Instruction {
     /// Return all memory accesses by the instruction - in expressions, captures, and memory manipulation
     pub fn get_memory_accesses(&self) -> MemoryAccesses {
         match self {
-            Instruction::Arithmetic {
+            Instruction::Arithmetic(Arithmetic {
                 destination,
                 source,
                 ..
-            }
-            | Instruction::Move {
+            })
+            | Instruction::Move(Move {
                 destination,
                 source,
-            } => MemoryAccesses {
+            }) => MemoryAccesses {
                 writes: set_from_optional_memory_reference![destination.get_memory_reference()],
                 reads: set_from_optional_memory_reference![source.get_memory_reference()],
                 ..Default::default()
             },
-            Instruction::CalibrationDefinition(definition) => {
+            Instruction::CalibrationDefinition(CalibrationDefinition(definition)) => {
                 let references: Vec<&MemoryReference> = definition
                     .parameters
                     .iter()
@@ -111,48 +118,49 @@ impl Instruction {
                     ..Default::default()
                 }
             }
-            Instruction::Capture {
+            Instruction::Capture(Capture {
                 memory_reference,
                 waveform,
                 ..
-            } => MemoryAccesses {
+            }) => MemoryAccesses {
                 captures: set_from_memory_references!(vec![memory_reference]),
                 reads: set_from_memory_references!(waveform.get_memory_references()),
                 ..Default::default()
             },
-            Instruction::CircuitDefinition { instructions, .. }
-            | Instruction::MeasureCalibrationDefinition { instructions, .. } => {
-                instructions.iter().fold(Default::default(), |acc, el| {
-                    let el_accesses = el.get_memory_accesses();
-                    MemoryAccesses {
-                        reads: merge_sets!(acc.reads, el_accesses.reads),
-                        writes: merge_sets!(acc.writes, el_accesses.writes),
-                        captures: merge_sets!(acc.captures, el_accesses.captures),
-                    }
-                })
-            }
-            Instruction::Declaration { .. } => Default::default(),
-            Instruction::Delay { duration, .. } => MemoryAccesses {
+            Instruction::CircuitDefinition(CircuitDefinition { instructions, .. })
+            | Instruction::MeasureCalibrationDefinition(MeasureCalibrationDefinition {
+                instructions,
+                ..
+            }) => instructions.iter().fold(Default::default(), |acc, el| {
+                let el_accesses = el.get_memory_accesses();
+                MemoryAccesses {
+                    reads: merge_sets!(acc.reads, el_accesses.reads),
+                    writes: merge_sets!(acc.writes, el_accesses.writes),
+                    captures: merge_sets!(acc.captures, el_accesses.captures),
+                }
+            }),
+            Instruction::Declaration(Declaration { .. }) => Default::default(),
+            Instruction::Delay(Delay { duration, .. }) => MemoryAccesses {
                 reads: set_from_memory_references!(duration.get_memory_references()),
                 ..Default::default()
             },
-            Instruction::Exchange { left, right } => MemoryAccesses {
+            Instruction::Exchange(Exchange { left, right }) => MemoryAccesses {
                 writes: merge_sets![
                     set_from_optional_memory_reference!(left.get_memory_reference()),
                     set_from_optional_memory_reference!(right.get_memory_reference())
                 ],
                 ..Default::default()
             },
-            Instruction::Fence { .. } => Default::default(),
-            Instruction::FrameDefinition { .. } => Default::default(),
-            Instruction::Gate { parameters, .. } => MemoryAccesses {
+            Instruction::Fence(Fence { .. }) => Default::default(),
+            Instruction::FrameDefinition(FrameDefinition { .. }) => Default::default(),
+            Instruction::Gate(Gate { parameters, .. }) => MemoryAccesses {
                 reads: set_from_memory_references!(parameters
                     .iter()
                     .flat_map(|param| param.get_memory_references())
                     .collect::<Vec<&MemoryReference>>()),
                 ..Default::default()
             },
-            Instruction::GateDefinition { matrix, .. } => {
+            Instruction::GateDefinition(GateDefinition { matrix, .. }) => {
                 let references = matrix
                     .iter()
                     .flat_map(|row| row.iter().flat_map(|cell| cell.get_memory_references()))
@@ -162,61 +170,61 @@ impl Instruction {
                     ..Default::default()
                 }
             }
-            Instruction::Halt => Default::default(),
-            Instruction::Jump { target: _ } => Default::default(),
-            Instruction::JumpWhen {
+            Instruction::Halt(_) => Default::default(),
+            Instruction::Jump(Jump { target: _ }) => Default::default(),
+            Instruction::JumpWhen(JumpWhen {
                 target: _,
                 condition,
-            }
-            | Instruction::JumpUnless {
+            })
+            | Instruction::JumpUnless(JumpUnless {
                 target: _,
                 condition,
-            } => MemoryAccesses {
+            }) => MemoryAccesses {
                 reads: set_from_memory_references!(vec![condition]),
                 ..Default::default()
             },
-            Instruction::Label(_) => Default::default(),
-            Instruction::Load {
+            Instruction::Label(Label(_)) => Default::default(),
+            Instruction::Load(Load {
                 destination,
                 source,
                 offset,
-            } => MemoryAccesses {
+            }) => MemoryAccesses {
                 writes: set_from_memory_references![vec![destination]],
                 reads: set_from_reference_vec![vec![source, &offset.name]],
                 ..Default::default()
             },
-            Instruction::Measurement { target, .. } => MemoryAccesses {
+            Instruction::Measurement(Measurement { target, .. }) => MemoryAccesses {
                 captures: set_from_optional_memory_reference!(target.as_ref()),
                 ..Default::default()
             },
-            Instruction::Pragma { .. } => Default::default(),
-            Instruction::Pulse { waveform, .. } => MemoryAccesses {
+            Instruction::Pragma(Pragma { .. }) => Default::default(),
+            Instruction::Pulse(Pulse { waveform, .. }) => MemoryAccesses {
                 reads: set_from_memory_references![waveform.get_memory_references()],
                 ..Default::default()
             },
-            Instruction::RawCapture {
+            Instruction::RawCapture(RawCapture {
                 duration,
                 memory_reference,
                 ..
-            } => MemoryAccesses {
+            }) => MemoryAccesses {
                 reads: set_from_memory_references![duration.get_memory_references()],
                 captures: set_from_memory_references![vec![memory_reference]],
                 ..Default::default()
             },
-            Instruction::Reset { .. } => Default::default(),
-            Instruction::SetFrequency { .. } => Default::default(),
-            Instruction::SetPhase { phase: expr, .. }
-            | Instruction::SetScale { scale: expr, .. }
-            | Instruction::ShiftPhase { phase: expr, .. } => MemoryAccesses {
+            Instruction::Reset(Reset { .. }) => Default::default(),
+            Instruction::SetFrequency(SetFrequency { .. }) => Default::default(),
+            Instruction::SetPhase(SetPhase { phase: expr, .. })
+            | Instruction::SetScale(SetScale { scale: expr, .. })
+            | Instruction::ShiftPhase(ShiftPhase { phase: expr, .. }) => MemoryAccesses {
                 reads: set_from_memory_references!(expr.get_memory_references()),
                 ..Default::default()
             },
-            Instruction::ShiftFrequency { .. } => Default::default(),
-            Instruction::Store {
+            Instruction::ShiftFrequency(ShiftFrequency { .. }) => Default::default(),
+            Instruction::Store(Store {
+                destination,
                 offset,
                 source,
-                destination,
-            } => MemoryAccesses {
+            }) => MemoryAccesses {
                 reads: merge_sets![
                     set_from_memory_references!(vec![offset]),
                     set_from_optional_memory_reference!(source.get_memory_reference())
@@ -224,8 +232,8 @@ impl Instruction {
                 writes: set_from_reference_vec![vec![destination]],
                 ..Default::default()
             },
-            Instruction::SwapPhases { .. } => Default::default(),
-            Instruction::WaveformDefinition { .. } => Default::default(),
+            Instruction::SwapPhases(SwapPhases { .. }) => Default::default(),
+            Instruction::WaveformDefinition(WaveformDefinition { .. }) => Default::default(),
         }
     }
 }

--- a/src/program/memory.rs
+++ b/src/program/memory.rs
@@ -17,11 +17,10 @@ use std::collections::HashSet;
 
 use crate::expression::Expression;
 use crate::instruction::{
-    Arithmetic, ArithmeticOperand, Capture, CircuitDefinition, Declaration, Delay, Exchange, Fence,
-    FrameDefinition, Gate, GateDefinition, Instruction, Jump, JumpUnless, JumpWhen, Label, Load,
-    MeasureCalibrationDefinition, Measurement, MemoryReference, Move, Pragma, Pulse, RawCapture,
-    Reset, SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, SwapPhases, Vector,
-    WaveformDefinition, WaveformInvocation,
+    Arithmetic, ArithmeticOperand, Capture, CircuitDefinition, Delay, Exchange, Gate,
+    GateDefinition, Instruction, Jump, JumpUnless, JumpWhen, Label, Load,
+    MeasureCalibrationDefinition, Measurement, MemoryReference, Move, Pulse, RawCapture, SetPhase,
+    SetScale, ShiftPhase, Store, Vector, WaveformInvocation,
 };
 
 #[derive(Clone, Debug, Hash, PartialEq)]
@@ -136,7 +135,7 @@ impl Instruction {
                     captures: merge_sets!(acc.captures, el_accesses.captures),
                 }
             }),
-            Instruction::Declaration(Declaration { .. }) => Default::default(),
+            Instruction::Declaration(_) => Default::default(),
             Instruction::Delay(Delay { duration, .. }) => MemoryAccesses {
                 reads: set_from_memory_references!(duration.get_memory_references()),
                 ..Default::default()
@@ -148,8 +147,8 @@ impl Instruction {
                 ],
                 ..Default::default()
             },
-            Instruction::Fence(Fence { .. }) => Default::default(),
-            Instruction::FrameDefinition(FrameDefinition { .. }) => Default::default(),
+            Instruction::Fence(_) => Default::default(),
+            Instruction::FrameDefinition(_) => Default::default(),
             Instruction::Gate(Gate { parameters, .. }) => MemoryAccesses {
                 reads: set_from_memory_references!(parameters
                     .iter()
@@ -167,7 +166,7 @@ impl Instruction {
                     ..Default::default()
                 }
             }
-            Instruction::Halt(_) => Default::default(),
+            Instruction::Halt => Default::default(),
             Instruction::Jump(Jump { target: _ }) => Default::default(),
             Instruction::JumpWhen(JumpWhen {
                 target: _,
@@ -194,7 +193,7 @@ impl Instruction {
                 captures: set_from_optional_memory_reference!(target.as_ref()),
                 ..Default::default()
             },
-            Instruction::Pragma(Pragma { .. }) => Default::default(),
+            Instruction::Pragma(_) => Default::default(),
             Instruction::Pulse(Pulse { waveform, .. }) => MemoryAccesses {
                 reads: set_from_memory_references![waveform.get_memory_references()],
                 ..Default::default()
@@ -208,15 +207,15 @@ impl Instruction {
                 captures: set_from_memory_references![vec![memory_reference]],
                 ..Default::default()
             },
-            Instruction::Reset(Reset { .. }) => Default::default(),
-            Instruction::SetFrequency(SetFrequency { .. }) => Default::default(),
+            Instruction::Reset(_) => Default::default(),
+            Instruction::SetFrequency(_) => Default::default(),
             Instruction::SetPhase(SetPhase { phase: expr, .. })
             | Instruction::SetScale(SetScale { scale: expr, .. })
             | Instruction::ShiftPhase(ShiftPhase { phase: expr, .. }) => MemoryAccesses {
                 reads: set_from_memory_references!(expr.get_memory_references()),
                 ..Default::default()
             },
-            Instruction::ShiftFrequency(ShiftFrequency { .. }) => Default::default(),
+            Instruction::ShiftFrequency(_) => Default::default(),
             Instruction::Store(Store {
                 destination,
                 offset,
@@ -229,8 +228,8 @@ impl Instruction {
                 writes: set_from_reference_vec![vec![destination]],
                 ..Default::default()
             },
-            Instruction::SwapPhases(SwapPhases { .. }) => Default::default(),
-            Instruction::WaveformDefinition(WaveformDefinition { .. }) => Default::default(),
+            Instruction::SwapPhases(_) => Default::default(),
+            Instruction::WaveformDefinition(_) => Default::default(),
         }
     }
 }

--- a/src/program/memory.rs
+++ b/src/program/memory.rs
@@ -1,12 +1,3 @@
-use std::collections::HashSet;
-
-use crate::instruction::{
-    Arithmetic, CalibrationDefinition, Capture, CircuitDefinition, Declaration, Delay, Exchange,
-    Fence, FrameDefinition, Gate, GateDefinition, Jump, JumpUnless, JumpWhen, Label, Load,
-    MeasureCalibrationDefinition, Measurement, Move, Pragma, Pulse, RawCapture, Reset,
-    SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, SwapPhases,
-    WaveformDefinition,
-};
 /**
  * Copyright 2021 Rigetti Computing
  *
@@ -22,9 +13,15 @@ use crate::instruction::{
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-use crate::{
-    expression::Expression,
-    instruction::{ArithmeticOperand, Instruction, MemoryReference, Vector, WaveformInvocation},
+use std::collections::HashSet;
+
+use crate::expression::Expression;
+use crate::instruction::{
+    Arithmetic, ArithmeticOperand, Capture, CircuitDefinition, Declaration, Delay, Exchange, Fence,
+    FrameDefinition, Gate, GateDefinition, Instruction, Jump, JumpUnless, JumpWhen, Label, Load,
+    MeasureCalibrationDefinition, Measurement, MemoryReference, Move, Pragma, Pulse, RawCapture,
+    Reset, SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, SwapPhases, Vector,
+    WaveformDefinition, WaveformInvocation,
 };
 
 #[derive(Clone, Debug, Hash, PartialEq)]
@@ -107,7 +104,7 @@ impl Instruction {
                 reads: set_from_optional_memory_reference![source.get_memory_reference()],
                 ..Default::default()
             },
-            Instruction::CalibrationDefinition(CalibrationDefinition(definition)) => {
+            Instruction::CalibrationDefinition(definition) => {
                 let references: Vec<&MemoryReference> = definition
                     .parameters
                     .iter()

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -16,10 +16,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use crate::{
-    instruction::{FrameIdentifier, Instruction, Waveform},
-    parser::{lex, parse_instructions},
-};
+use crate::parser::{lex, parse_instructions};
 
 mod calibration;
 mod frame;
@@ -29,6 +26,13 @@ mod memory;
 pub use self::calibration::CalibrationSet;
 pub use self::frame::FrameSet;
 pub use self::memory::MemoryRegion;
+use crate::instruction::{
+    Arithmetic, CalibrationDefinition, Capture, CircuitDefinition, Declaration, Delay, Exchange,
+    Fence, FrameDefinition, FrameIdentifier, Gate, GateDefinition, Halt, Instruction, Jump,
+    JumpUnless, JumpWhen, Label, Load, MeasureCalibrationDefinition, Measurement, Move, Pragma,
+    Pulse, RawCapture, Reset, SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store,
+    SwapPhases, Waveform, WaveformDefinition,
+};
 
 /// A Quil Program instance describes a quantum program with metadata used in execution.
 ///
@@ -57,27 +61,25 @@ impl Program {
 
     /// Add an instruction to the end of the program.
     pub fn add_instruction(&mut self, instruction: Instruction) {
-        use Instruction::*;
-
         match instruction {
-            CalibrationDefinition(calibration) => {
+            Instruction::CalibrationDefinition(CalibrationDefinition(calibration)) => {
                 self.calibrations.push(calibration);
             }
-            FrameDefinition {
+            Instruction::FrameDefinition(FrameDefinition {
                 identifier,
                 attributes,
-            } => {
+            }) => {
                 self.frames.insert(identifier, attributes);
             }
-            Instruction::Declaration {
+            Instruction::Declaration(Declaration {
                 name,
                 size,
                 sharing,
-            } => {
+            }) => {
                 self.memory_regions
                     .insert(name, MemoryRegion { size, sharing });
             }
-            WaveformDefinition { name, definition } => {
+            Instruction::WaveformDefinition(WaveformDefinition { name, definition }) => {
                 self.waveforms.insert(name, definition);
             }
             other => self.instructions.push(other),
@@ -116,71 +118,72 @@ impl Program {
         instruction: &'a Instruction,
         include_blocked: bool,
     ) -> Option<Vec<&'a FrameIdentifier>> {
-        use Instruction::*;
         match &instruction {
-            Pulse {
+            Instruction::Pulse(Pulse {
                 blocking, frame, ..
-            } => {
+            }) => {
                 if *blocking && include_blocked {
                     Some(self.frames.get_keys())
                 } else {
                     Some(vec![frame])
                 }
             }
-            Delay {
+            Instruction::Delay(Delay {
                 frame_names,
                 qubits,
                 ..
-            } => {
+            }) => {
                 let frame_ids = self.frames.get_matching_keys(qubits, frame_names);
                 Some(frame_ids)
             }
-            Fence { qubits } => {
+            Instruction::Fence(Fence { qubits }) => {
                 if qubits.is_empty() {
                     Some(self.frames.get_keys())
                 } else {
                     Some(self.frames.get_matching_keys(qubits, &[]))
                 }
             }
-            Capture {
+            Instruction::Capture(Capture {
                 blocking, frame, ..
-            }
-            | RawCapture {
+            })
+            | Instruction::RawCapture(RawCapture {
                 blocking, frame, ..
-            } => {
+            }) => {
                 if *blocking && include_blocked {
                     Some(self.frames.get_keys())
                 } else {
                     Some(vec![frame])
                 }
             }
-            SetFrequency { frame, .. }
-            | SetPhase { frame, .. }
-            | SetScale { frame, .. }
-            | ShiftFrequency { frame, .. }
-            | ShiftPhase { frame, .. } => Some(vec![frame]),
-            SwapPhases { frame_1, frame_2 } => Some(vec![frame_1, frame_2]),
-            Gate { .. }
-            | CircuitDefinition { .. }
-            | GateDefinition { .. }
-            | Declaration { .. }
-            | Measurement { .. }
-            | Reset { .. }
-            | CalibrationDefinition(_)
-            | FrameDefinition { .. }
-            | MeasureCalibrationDefinition { .. }
-            | Pragma { .. }
-            | WaveformDefinition { .. }
-            | Arithmetic { .. }
-            | Halt
-            | Label(_)
-            | Move { .. }
-            | Exchange { .. }
-            | Load { .. }
-            | Store { .. }
-            | Jump { .. }
-            | JumpWhen { .. }
-            | JumpUnless { .. } => None,
+            Instruction::SetFrequency(SetFrequency { frame, .. })
+            | Instruction::SetPhase(SetPhase { frame, .. })
+            | Instruction::SetScale(SetScale { frame, .. })
+            | Instruction::ShiftFrequency(ShiftFrequency { frame, .. })
+            | Instruction::ShiftPhase(ShiftPhase { frame, .. }) => Some(vec![frame]),
+            Instruction::SwapPhases(SwapPhases { frame_1, frame_2 }) => {
+                Some(vec![frame_1, frame_2])
+            }
+            Instruction::Gate(Gate { .. })
+            | Instruction::CircuitDefinition(CircuitDefinition { .. })
+            | Instruction::GateDefinition(GateDefinition { .. })
+            | Instruction::Declaration(Declaration { .. })
+            | Instruction::Measurement(Measurement { .. })
+            | Instruction::Reset(Reset { .. })
+            | Instruction::CalibrationDefinition(CalibrationDefinition(_))
+            | Instruction::FrameDefinition(FrameDefinition { .. })
+            | Instruction::MeasureCalibrationDefinition(MeasureCalibrationDefinition { .. })
+            | Instruction::Pragma(Pragma { .. })
+            | Instruction::WaveformDefinition(WaveformDefinition { .. })
+            | Instruction::Arithmetic(Arithmetic { .. })
+            | Instruction::Halt(Halt { .. })
+            | Instruction::Label(Label(_))
+            | Instruction::Move(Move { .. })
+            | Instruction::Exchange(Exchange { .. })
+            | Instruction::Load(Load { .. })
+            | Instruction::Store(Store { .. })
+            | Instruction::Jump(Jump { .. })
+            | Instruction::JumpWhen(JumpWhen { .. })
+            | Instruction::JumpUnless(JumpUnless { .. }) => None,
         }
     }
 
@@ -189,18 +192,18 @@ impl Program {
 
         if include_headers {
             result.extend(self.memory_regions.iter().map(|(name, descriptor)| {
-                Instruction::Declaration {
+                Instruction::Declaration(Declaration {
                     name: name.clone(),
                     size: descriptor.size.clone(),
                     sharing: descriptor.sharing.clone(),
-                }
+                })
             }));
             result.extend(self.frames.to_instructions());
             result.extend(self.waveforms.iter().map(|(name, definition)| {
-                Instruction::WaveformDefinition {
+                Instruction::WaveformDefinition(WaveformDefinition {
                     name: name.clone(),
                     definition: definition.clone(),
-                }
+                })
             }));
             result.extend(self.calibrations.to_instructions());
         }

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -16,23 +16,23 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
+use crate::instruction::{
+    Arithmetic, Capture, CircuitDefinition, Declaration, Delay, Exchange, Fence, FrameDefinition,
+    FrameIdentifier, Gate, GateDefinition, Halt, Instruction, Jump, JumpUnless, JumpWhen, Label,
+    Load, MeasureCalibrationDefinition, Measurement, Move, Pragma, Pulse, RawCapture, Reset,
+    SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, SwapPhases, Waveform,
+    WaveformDefinition,
+};
 use crate::parser::{lex, parse_instructions};
+
+pub use self::calibration::CalibrationSet;
+pub use self::frame::FrameSet;
+pub use self::memory::MemoryRegion;
 
 mod calibration;
 mod frame;
 pub mod graph;
 mod memory;
-
-pub use self::calibration::CalibrationSet;
-pub use self::frame::FrameSet;
-pub use self::memory::MemoryRegion;
-use crate::instruction::{
-    Arithmetic, CalibrationDefinition, Capture, CircuitDefinition, Declaration, Delay, Exchange,
-    Fence, FrameDefinition, FrameIdentifier, Gate, GateDefinition, Halt, Instruction, Jump,
-    JumpUnless, JumpWhen, Label, Load, MeasureCalibrationDefinition, Measurement, Move, Pragma,
-    Pulse, RawCapture, Reset, SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store,
-    SwapPhases, Waveform, WaveformDefinition,
-};
 
 /// A Quil Program instance describes a quantum program with metadata used in execution.
 ///
@@ -62,7 +62,7 @@ impl Program {
     /// Add an instruction to the end of the program.
     pub fn add_instruction(&mut self, instruction: Instruction) {
         match instruction {
-            Instruction::CalibrationDefinition(CalibrationDefinition(calibration)) => {
+            Instruction::CalibrationDefinition(calibration) => {
                 self.calibrations.push(calibration);
             }
             Instruction::FrameDefinition(FrameDefinition {
@@ -169,7 +169,7 @@ impl Program {
             | Instruction::Declaration(Declaration { .. })
             | Instruction::Measurement(Measurement { .. })
             | Instruction::Reset(Reset { .. })
-            | Instruction::CalibrationDefinition(CalibrationDefinition(_))
+            | Instruction::CalibrationDefinition(_)
             | Instruction::FrameDefinition(FrameDefinition { .. })
             | Instruction::MeasureCalibrationDefinition(MeasureCalibrationDefinition { .. })
             | Instruction::Pragma(Pragma { .. })
@@ -242,8 +242,9 @@ impl FromStr for Program {
 
 #[cfg(test)]
 mod tests {
-    use super::Program;
     use std::str::FromStr;
+
+    use super::Program;
 
     #[test]
     fn program_eq() {

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -17,10 +17,8 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use crate::instruction::{
-    Arithmetic, Capture, CircuitDefinition, Declaration, Delay, Exchange, Fence, FrameDefinition,
-    FrameIdentifier, Gate, GateDefinition, Halt, Instruction, Jump, JumpUnless, JumpWhen, Label,
-    Load, MeasureCalibrationDefinition, Measurement, Move, Pragma, Pulse, RawCapture, Reset,
-    SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, SwapPhases, Waveform,
+    Capture, Declaration, Delay, Fence, FrameDefinition, FrameIdentifier, Instruction, Pulse,
+    RawCapture, SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, SwapPhases, Waveform,
     WaveformDefinition,
 };
 use crate::parser::{lex, parse_instructions};
@@ -163,27 +161,27 @@ impl Program {
             Instruction::SwapPhases(SwapPhases { frame_1, frame_2 }) => {
                 Some(vec![frame_1, frame_2])
             }
-            Instruction::Gate(Gate { .. })
-            | Instruction::CircuitDefinition(CircuitDefinition { .. })
-            | Instruction::GateDefinition(GateDefinition { .. })
-            | Instruction::Declaration(Declaration { .. })
-            | Instruction::Measurement(Measurement { .. })
-            | Instruction::Reset(Reset { .. })
+            Instruction::Gate(_)
+            | Instruction::CircuitDefinition(_)
+            | Instruction::GateDefinition(_)
+            | Instruction::Declaration(_)
+            | Instruction::Measurement(_)
+            | Instruction::Reset(_)
             | Instruction::CalibrationDefinition(_)
-            | Instruction::FrameDefinition(FrameDefinition { .. })
-            | Instruction::MeasureCalibrationDefinition(MeasureCalibrationDefinition { .. })
-            | Instruction::Pragma(Pragma { .. })
-            | Instruction::WaveformDefinition(WaveformDefinition { .. })
-            | Instruction::Arithmetic(Arithmetic { .. })
-            | Instruction::Halt(Halt { .. })
-            | Instruction::Label(Label(_))
-            | Instruction::Move(Move { .. })
-            | Instruction::Exchange(Exchange { .. })
-            | Instruction::Load(Load { .. })
-            | Instruction::Store(Store { .. })
-            | Instruction::Jump(Jump { .. })
-            | Instruction::JumpWhen(JumpWhen { .. })
-            | Instruction::JumpUnless(JumpUnless { .. }) => None,
+            | Instruction::FrameDefinition(_)
+            | Instruction::MeasureCalibrationDefinition(_)
+            | Instruction::Pragma(_)
+            | Instruction::WaveformDefinition(_)
+            | Instruction::Arithmetic(_)
+            | Instruction::Halt
+            | Instruction::Label(_)
+            | Instruction::Move(_)
+            | Instruction::Exchange(_)
+            | Instruction::Load(_)
+            | Instruction::Store(_)
+            | Instruction::Jump(_)
+            | Instruction::JumpWhen(_)
+            | Instruction::JumpUnless(_) => None,
         }
     }
 


### PR DESCRIPTION
This enables stuff like
```
fn compile_gate(gate: Gate) -> Option<Vec<Gate>> { ... }
```
where before you would've needed
```
fn compile_gate(gate: Instruction) -> Option<Vec<Instruction>> {
    match gate {
        Gate { .. } => {
            // ...
        }
        _ => // not a gate :(
    }
}
```

It does make some stuff more verbose, but generally I think that's constrained to library code, and not consumer code.

Closes #21 