### PR TITLE
Fix: Allow indented comments when parsing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 Cargo.lock
 node_modules
+
+# JetBrains Editors
+.idea/

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -213,10 +213,9 @@ pub fn parse_vector<'a>(input: ParserInput<'a>) -> ParserResult<'a, Vector> {
 /// once the first other token is encountered.
 pub fn skip_newlines_and_comments<'a>(input: ParserInput<'a>) -> ParserResult<'a, ()> {
     let (input, _) = many0(alt((
-        value((), token!(Comment(v))),
+        preceded(many0(token!(Indentation)), value((), token!(Comment(v)))),
         token!(NewLine),
         token!(Semicolon),
-        preceded(many0(token!(Indentation)), value((), token!(Comment(v)))),
     )))(input)?;
     Ok((input, ()))
 }


### PR DESCRIPTION
First time using `nom` so let me know if there's a cleaner way to do this.