### PR TITLE
Upgrade: impl Hash and Eq for Expression for use in deduplication.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ serde = { version = "1.0.125", features = ["derive"] }
 
 [dev-dependencies]
 insta = "1.7.1"
+proptest = "1.0.0"
+proptest-derive = "0.3.0"

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -17,6 +17,7 @@ use crate::{imag, instruction::MemoryReference, real};
 use std::collections::HashMap;
 use std::f64::consts::PI;
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EvaluationError {
@@ -43,6 +44,15 @@ pub enum Expression {
     },
     Variable(String),
 }
+
+#[allow(clippy::derive_hash_xor_eq)]
+impl Hash for Expression {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.to_string().hash(state);
+    }
+}
+
+impl Eq for Expression {}
 
 /// Compute the result of an infix expression where both operands are complex.
 fn calculate_infix(

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -308,6 +308,7 @@ mod tests {
         real,
     };
     use num_complex::Complex64;
+    use std::collections::HashSet;
     use std::{collections::HashMap, f64::consts::PI};
 
     #[test]
@@ -378,5 +379,43 @@ mod tests {
             let evaluated_complex = evaluated.evaluate_to_complex(&case.environment);
             assert_eq!(evaluated_complex, case.evaluated_complex)
         }
+    }
+
+    #[test]
+    fn hash() {
+        let first = Expression::Infix {
+            left: Box::new(Expression::Number(real!(1.0))),
+            operator: InfixOperator::Plus,
+            right: Box::new(Expression::Number(real!(2.0))),
+        };
+        let matching = first.clone();
+        let differing = Expression::Number(real!(3.0));
+
+        let mut set = HashSet::new();
+        set.insert(first);
+
+        assert!(set.contains(&matching));
+        assert!(!set.contains(&differing))
+    }
+
+    #[test]
+    #[should_panic]
+    /// Not implemented yet, see https://github.com/rigetti/quil-rust/issues/27
+    fn hash_commutative() {
+        let first = Expression::Infix {
+            left: Box::new(Expression::Number(real!(1.0))),
+            operator: InfixOperator::Plus,
+            right: Box::new(Expression::Number(real!(2.0))),
+        };
+        let second = Expression::Infix {
+            left: Box::new(Expression::Number(real!(2.0))),
+            operator: InfixOperator::Plus,
+            right: Box::new(Expression::Number(real!(1.0))),
+        };
+
+        let mut set = HashSet::new();
+        set.insert(first);
+
+        assert!(set.contains(&second));
     }
 }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -14,17 +14,20 @@
  * limitations under the License.
  **/
 use crate::{imag, instruction::MemoryReference, real};
-use std::collections::HashMap;
+use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::f64::consts::PI;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+
+#[cfg(test)]
+use proptest_derive::Arbitrary;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EvaluationError {
     Incomplete,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum Expression {
     Address(MemoryReference),
     FunctionCall {
@@ -45,10 +48,91 @@ pub enum Expression {
     Variable(String),
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+/// Hash value helper: turn a hashable thing into a u64.
+fn _hash_to_u64<T: Hash>(t: &T) -> u64 {
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    s.finish()
+}
+
 impl Hash for Expression {
+    // Implemented by hand since we can't derive with f64s hidden inside.
+    // Also to understand when things should be the same, like with commutativity (`1 + 2 == 2 + 1`).
+    // See https://github.com/rigetti/quil-rust/issues/27
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.to_string().hash(state);
+        use std::cmp::{max_by_key, min_by_key};
+        use Expression::*;
+        match self {
+            Address(m) => {
+                "Address".hash(state);
+                m.hash(state);
+            }
+            FunctionCall {
+                function,
+                expression,
+            } => {
+                "FunctionCall".hash(state);
+                function.hash(state);
+                expression.hash(state);
+            }
+            Infix {
+                left,
+                operator,
+                right,
+            } => {
+                "Infix".hash(state);
+                operator.hash(state);
+                match operator {
+                    InfixOperator::Plus | InfixOperator::Star => {
+                        // commutative, so put left & right in decreasing order by hash value
+                        let (a, b) = (
+                            min_by_key(left, right, _hash_to_u64),
+                            max_by_key(left, right, _hash_to_u64),
+                        );
+                        a.hash(state);
+                        b.hash(state);
+                    }
+                    _ => {
+                        left.hash(state);
+                        right.hash(state);
+                    }
+                }
+            }
+            Number(n) => {
+                "Number".hash(state);
+                // Skip zero values (akin to `format_complex`).
+                // Also, since f64 isn't hashable, use the u64 binary representation.
+                // The docs claim this is rather portable: https://doc.rust-lang.org/std/primitive.f64.html#method.to_bits
+                if n.re.abs() > 0f64 {
+                    n.re.to_bits().hash(state)
+                }
+                if n.im.abs() > 0f64 {
+                    n.im.to_bits().hash(state)
+                }
+            }
+            PiConstant => {
+                "PiConstant".hash(state);
+            }
+            Prefix {
+                operator,
+                expression,
+            } => {
+                "Prefix".hash(state);
+                operator.hash(state);
+                expression.hash(state);
+            }
+            Variable(v) => {
+                "Variable".hash(state);
+                v.hash(state);
+            }
+        }
+    }
+}
+
+impl PartialEq for Expression {
+    // Partial equality by hash value
+    fn eq(&self, other: &Self) -> bool {
+        _hash_to_u64(self) == _hash_to_u64(other)
     }
 }
 
@@ -228,7 +312,8 @@ impl fmt::Display for Expression {
 }
 
 /// A function defined within Quil syntax.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub enum ExpressionFunction {
     Cis,
     Cosine,
@@ -254,7 +339,8 @@ impl fmt::Display for ExpressionFunction {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub enum PrefixOperator {
     Plus,
     Minus,
@@ -274,7 +360,8 @@ impl fmt::Display for PrefixOperator {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub enum InfixOperator {
     Caret,
     Plus,
@@ -302,14 +389,12 @@ impl fmt::Display for InfixOperator {
 
 #[cfg(test)]
 mod tests {
-    use super::PrefixOperator;
-    use crate::{
-        expression::{EvaluationError, Expression, ExpressionFunction, InfixOperator},
-        real,
-    };
+    use super::*;
+    use crate::{instruction::MemoryReference, real};
     use num_complex::Complex64;
-    use std::collections::HashSet;
-    use std::{collections::HashMap, f64::consts::PI};
+    use proptest::prelude::*;
+    use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
+    use std::f64::consts::PI;
 
     #[test]
     fn evaluate() {
@@ -381,41 +466,116 @@ mod tests {
         }
     }
 
-    #[test]
-    fn hash() {
-        let first = Expression::Infix {
-            left: Box::new(Expression::Number(real!(1.0))),
-            operator: InfixOperator::Plus,
-            right: Box::new(Expression::Number(real!(2.0))),
-        };
-        let matching = first.clone();
-        let differing = Expression::Number(real!(3.0));
-
-        let mut set = HashSet::new();
-        set.insert(first);
-
-        assert!(set.contains(&matching));
-        assert!(!set.contains(&differing))
+    /// Generate an arbitrary Expression for a property test.
+    /// See https://docs.rs/proptest/1.0.0/proptest/prelude/trait.Strategy.html#method.prop_recursive
+    fn arb_expr() -> impl Strategy<Value = Expression> {
+        use Expression::*;
+        let leaf = prop_oneof![
+            any::<MemoryReference>().prop_map(Address),
+            (any::<f64>(), any::<f64>())
+                .prop_map(|(re, im)| Number(num_complex::Complex64::new(re, im))),
+            Just(PiConstant),
+            ".*".prop_map(Variable),
+        ];
+        (leaf).prop_recursive(
+            4,  // No more than 4 branch levels deep
+            64, // Target around 64 total nodes
+            2,  // Each "collection" is up to 2 elements
+            |expr| {
+                prop_oneof![
+                    (any::<ExpressionFunction>(), expr.clone()).prop_map(|(function, e)| {
+                        FunctionCall {
+                            function,
+                            expression: Box::new(e),
+                        }
+                    }),
+                    (expr.clone(), any::<InfixOperator>(), expr.clone()).prop_map(
+                        |(l, operator, r)| Infix {
+                            left: Box::new(l),
+                            operator,
+                            right: Box::new(r)
+                        }
+                    ),
+                    (any::<PrefixOperator>(), expr).prop_map(|(operator, e)| Prefix {
+                        operator,
+                        expression: Box::new(e)
+                    })
+                ]
+            },
+        )
     }
 
-    #[test]
-    #[should_panic]
-    /// Not implemented yet, see https://github.com/rigetti/quil-rust/issues/27
-    fn hash_commutative() {
-        let first = Expression::Infix {
-            left: Box::new(Expression::Number(real!(1.0))),
-            operator: InfixOperator::Plus,
-            right: Box::new(Expression::Number(real!(2.0))),
-        };
-        let second = Expression::Infix {
-            left: Box::new(Expression::Number(real!(2.0))),
-            operator: InfixOperator::Plus,
-            right: Box::new(Expression::Number(real!(1.0))),
-        };
+    proptest! {
 
-        let mut set = HashSet::new();
-        set.insert(first);
+        #[test]
+        fn eq(a in any::<f64>(), b in any::<f64>()) {
+            let first = Expression::Infix {
+                left: Box::new(Expression::Number(real!(a))),
+                operator: InfixOperator::Plus,
+                right: Box::new(Expression::Number(real!(b))),
+            };
+            let matching = first.clone();
+            let differing = Expression::Number(real!(a + b));
+            prop_assert_eq!(&first, &matching);
+            prop_assert_ne!(&first, &differing);
+        }
 
-        assert!(set.contains(&second));
+        #[test]
+        fn eq_commutative(a in any::<f64>(), b in any::<f64>()) {
+            let first = Expression::Infix{
+                left: Box::new(Expression::Number(real!(a))),
+                operator: InfixOperator::Plus,
+                right: Box::new(Expression::Number(real!(b))),
+            };
+            let second = Expression::Infix{
+                left: Box::new(Expression::Number(real!(b))),
+                operator: InfixOperator::Plus,
+                right: Box::new(Expression::Number(real!(a))),
+            };
+            prop_assert_eq!(first, second);
+        }
+
+        #[test]
+        fn hash(a in any::<f64>(), b in any::<f64>()) {
+            let first = Expression::Infix {
+                left: Box::new(Expression::Number(real!(a))),
+                operator: InfixOperator::Plus,
+                right: Box::new(Expression::Number(real!(b))),
+            };
+            let matching = first.clone();
+            let differing = Expression::Number(real!(a + b));
+            let mut set = HashSet::new();
+            set.insert(first);
+            assert!(set.contains(&matching));
+            assert!(!set.contains(&differing))
+        }
+
+        #[test]
+        fn hash_commutative(a in any::<f64>(), b in any::<f64>()) {
+            let first = Expression::Infix{
+                left: Box::new(Expression::Number(real!(a))),
+                operator: InfixOperator::Plus,
+                right: Box::new(Expression::Number(real!(b))),
+            };
+            let second = Expression::Infix{
+                left: Box::new(Expression::Number(real!(b))),
+                operator: InfixOperator::Plus,
+                right: Box::new(Expression::Number(real!(a))),
+            };
+            let mut set = HashSet::new();
+            set.insert(first);
+            assert!(set.contains(&second));
+        }
+
+        #[test]
+        fn eq_implies_hash_eq(x in arb_expr(), y in arb_expr()) {
+            let mut s = DefaultHasher::new();
+            x.hash(&mut s);
+            let h_x = s.finish();
+            y.hash(&mut s);
+            let h_y = s.finish();
+            prop_assert_eq!(x == y, h_x == h_y);
+        }
+
     }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -18,6 +18,9 @@ use std::{collections::HashMap, fmt};
 
 use crate::expression::Expression;
 
+#[cfg(test)]
+use proptest_derive::Arbitrary;
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum ArithmeticOperand {
     LiteralInteger(i64),
@@ -200,6 +203,7 @@ impl fmt::Display for WaveformInvocation {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct MemoryReference {
     pub name: String,
     pub index: u64,


### PR DESCRIPTION
This is to allow the pyQuil style of expression de-duplication by substitution. Allowing for use in a HashSet directly feels a lot better than a map of Expression.to_string() => Expression, and this way we can tweak how we differentiate between expressions (e.g. evaluating/simplifying automatically) at some point if we want to.

Note that Clippy is rightly angry about implementing `Hash` on something which has derived `PartialEq`. This is ultimately because we store floats in expressions and floats are not hashable. That problem can also lead to issues with equality anyway so I just ignored for now. The recommendation is to create a `PartialEq` implementation by hand that is guaranteed to have the same results as `Hash`.

We probably also want to do a custom PartialEq/Hash at some point which allows for the commutative property in expressions (e.g. 1 + 2 == 2 + 1)