### PR TITLE
New: Support parsing SET-SCALE, SET-FREQUENCY, and SHIFT-FREQUENCY.

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -288,7 +288,7 @@ pub enum Instruction {
     },
     SetFrequency {
         frame: FrameIdentifier,
-        frequency: f64,
+        frequency: Expression,
     },
     SetPhase {
         frame: FrameIdentifier,
@@ -300,7 +300,7 @@ pub enum Instruction {
     },
     ShiftFrequency {
         frame: FrameIdentifier,
-        frequency: f64,
+        frequency: Expression,
     },
     ShiftPhase {
         frame: FrameIdentifier,

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -31,9 +31,7 @@ use super::{
 use crate::parser::common::parse_variable_qubit;
 use crate::parser::instruction::parse_block;
 use crate::{
-    instruction::{
-        ArithmeticOperand, ArithmeticOperator, Calibration, FrameIdentifier, Instruction, Waveform,
-    },
+    instruction::{ArithmeticOperand, ArithmeticOperator, Calibration, Instruction, Waveform},
     parser::{
         error::{Error, ErrorKind},
         lexer::Token,
@@ -322,17 +320,16 @@ pub fn parse_pragma<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction>
     ))
 }
 
-/// Parse a pulse instruction, **including the PULSE keyword**.
-pub fn parse_pulse<'a>(input: ParserInput<'a>, blocking: bool) -> ParserResult<'a, Instruction> {
-    let (input, qubits) = many0(parse_qubit)(input)?;
-    let (input, name) = token!(String(v))(input)?;
+/// Parse the contents of a `PULSE` instruction.
+pub fn parse_pulse(input: ParserInput, blocking: bool) -> ParserResult<Instruction> {
+    let (input, frame) = parse_frame_identifier(input)?;
     let (input, waveform) = parse_waveform_invocation(input)?;
 
     Ok((
         input,
         Instruction::Pulse {
             blocking,
-            frame: FrameIdentifier { name, qubits },
+            frame,
             waveform,
         },
     ))
@@ -353,6 +350,30 @@ pub fn parse_raw_capture(input: ParserInput, blocking: bool) -> ParserResult<Ins
             memory_reference,
         },
     ))
+}
+
+/// Parse the contents of a `SET-FREQUENCY` instruction.
+pub fn parse_set_frequency(input: ParserInput) -> ParserResult<Instruction> {
+    let (input, frame) = parse_frame_identifier(input)?;
+    let (input, frequency) = parse_expression(input)?;
+
+    Ok((input, Instruction::SetFrequency { frame, frequency }))
+}
+
+/// Parse the contents of a `SET-SCALE` instruction.
+pub fn parse_set_scale(input: ParserInput) -> ParserResult<Instruction> {
+    let (input, frame) = parse_frame_identifier(input)?;
+    let (input, scale) = parse_expression(input)?;
+
+    Ok((input, Instruction::SetScale { frame, scale }))
+}
+
+/// Parse the contents of a `SHIFT-FREQUENCY` instruction.
+pub fn parse_shift_frequency(input: ParserInput) -> ParserResult<Instruction> {
+    let (input, frame) = parse_frame_identifier(input)?;
+    let (input, frequency) = parse_expression(input)?;
+
+    Ok((input, Instruction::ShiftFrequency { frame, frequency }))
 }
 
 /// Parse the contents of a `MEASURE` instruction.

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -80,10 +80,10 @@ pub fn parse_instruction(input: ParserInput) -> ParserResult<Instruction> {
                 Command::Pulse => command::parse_pulse(remainder, true),
                 Command::RawCapture => command::parse_raw_capture(remainder, true),
                 // Command::Reset => {}
-                // Command::SetFrequency => {}
+                Command::SetFrequency => command::parse_set_frequency(remainder),
                 // Command::SetPhase => {}
-                // Command::SetScale => {}
-                // Command::ShiftFrequency => {}
+                Command::SetScale => command::parse_set_scale(remainder),
+                Command::ShiftFrequency => command::parse_shift_frequency(remainder),
                 // Command::ShiftPhase => {}
                 Command::Store => command::parse_store(remainder),
                 Command::Sub => command::parse_arithmetic(ArithmeticOperator::Subtract, remainder),
@@ -465,4 +465,85 @@ mod tests {
             source: ArithmeticOperand::LiteralReal(1.0)
         }]
     );
+
+    #[test]
+    fn parse_set_scale() {
+        let tokens = lex(r#"SET-SCALE 0 "rf" 1.0; SET-SCALE 0 1 "rf" theta"#);
+        let (remainder, parsed) = parse_instructions(&tokens).unwrap();
+        let expected = vec![
+            Instruction::SetScale {
+                frame: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(0)],
+                },
+                scale: Expression::Number(real!(1.0)),
+            },
+            Instruction::SetScale {
+                frame: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(0), Qubit::Fixed(1)],
+                },
+                scale: Expression::Address(MemoryReference {
+                    name: String::from("theta"),
+                    index: 0,
+                }),
+            },
+        ];
+        assert_eq!(remainder.len(), 0);
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn parse_set_frequency() {
+        let tokens = lex(r#"SET-FREQUENCY 0 "rf" 1.0; SET-FREQUENCY 0 1 "rf" theta"#);
+        let (remainder, parsed) = parse_instructions(&tokens).unwrap();
+        let expected = vec![
+            Instruction::SetFrequency {
+                frame: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(0)],
+                },
+                frequency: Expression::Number(real!(1.0)),
+            },
+            Instruction::SetFrequency {
+                frame: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(0), Qubit::Fixed(1)],
+                },
+                frequency: Expression::Address(MemoryReference {
+                    name: String::from("theta"),
+                    index: 0,
+                }),
+            },
+        ];
+        assert_eq!(remainder.len(), 0);
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn parse_shift_frequency() {
+        let tokens = lex(r#"SHIFT-FREQUENCY 0 "rf" 1.0; SHIFT-FREQUENCY 0 1 "rf" theta"#);
+        let (remainder, parsed) = parse_instructions(&tokens).unwrap();
+        let expected = vec![
+            Instruction::ShiftFrequency {
+                frame: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(0)],
+                },
+                frequency: Expression::Number(real!(1.0)),
+            },
+            Instruction::ShiftFrequency {
+                frame: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(0), Qubit::Fixed(1)],
+                },
+                frequency: Expression::Address(MemoryReference {
+                    name: String::from("theta"),
+                    index: 0,
+                }),
+            },
+        ];
+        assert_eq!(remainder.len(), 0);
+        assert_eq!(parsed, expected);
+    }
 }


### PR DESCRIPTION
For the two frequency commands, [the spec] agrees with the previous structs in that they should take floats, but [pyQuil] allows expressions and does conversion on them, so I assume we should stick with that implementation.

[the spec]: https://github.com/quil-lang/quil/blob/master/rfcs/analog/spec_changes.md#frequency
[pyQuil]: https://github.com/rigetti/pyquil/blob/9545776eff57362aed18b619a36182c556b2296f/pyquil/api/_rewrite_arithmetic.py#L107