### PR TITLE
New: Parse `SET-PHASE` and `SHIFT-PHASE`.

### DIFF
--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -360,6 +360,14 @@ pub fn parse_set_frequency(input: ParserInput) -> ParserResult<Instruction> {
     Ok((input, Instruction::SetFrequency { frame, frequency }))
 }
 
+/// Parse the contents of a `SET-PHASE` instruction.
+pub fn parse_set_phase(input: ParserInput) -> ParserResult<Instruction> {
+    let (input, frame) = parse_frame_identifier(input)?;
+    let (input, phase) = parse_expression(input)?;
+
+    Ok((input, Instruction::SetPhase { frame, phase }))
+}
+
 /// Parse the contents of a `SET-SCALE` instruction.
 pub fn parse_set_scale(input: ParserInput) -> ParserResult<Instruction> {
     let (input, frame) = parse_frame_identifier(input)?;
@@ -374,6 +382,14 @@ pub fn parse_shift_frequency(input: ParserInput) -> ParserResult<Instruction> {
     let (input, frequency) = parse_expression(input)?;
 
     Ok((input, Instruction::ShiftFrequency { frame, frequency }))
+}
+
+/// Parse the contents of a `SHIFT-PHASE` instruction.
+pub fn parse_shift_phase(input: ParserInput) -> ParserResult<Instruction> {
+    let (input, frame) = parse_frame_identifier(input)?;
+    let (input, phase) = parse_expression(input)?;
+
+    Ok((input, Instruction::ShiftPhase { frame, phase }))
 }
 
 /// Parse the contents of a `MEASURE` instruction.

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -81,10 +81,10 @@ pub fn parse_instruction(input: ParserInput) -> ParserResult<Instruction> {
                 Command::RawCapture => command::parse_raw_capture(remainder, true),
                 // Command::Reset => {}
                 Command::SetFrequency => command::parse_set_frequency(remainder),
-                // Command::SetPhase => {}
+                Command::SetPhase => command::parse_set_phase(remainder),
                 Command::SetScale => command::parse_set_scale(remainder),
                 Command::ShiftFrequency => command::parse_shift_frequency(remainder),
-                // Command::ShiftPhase => {}
+                Command::ShiftPhase => command::parse_shift_phase(remainder),
                 Command::Store => command::parse_store(remainder),
                 Command::Sub => command::parse_arithmetic(ArithmeticOperator::Subtract, remainder),
                 // Command::Wait => {}
@@ -467,6 +467,33 @@ mod tests {
     );
 
     #[test]
+    fn parse_set_phase() {
+        let tokens = lex(r#"SET-PHASE 0 "rf" 1.0; SET-PHASE 0 1 "rf" theta"#);
+        let (remainder, parsed) = parse_instructions(&tokens).unwrap();
+        let expected = vec![
+            Instruction::SetPhase {
+                frame: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(0)],
+                },
+                phase: Expression::Number(real!(1.0)),
+            },
+            Instruction::SetPhase {
+                frame: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(0), Qubit::Fixed(1)],
+                },
+                phase: Expression::Address(MemoryReference {
+                    name: String::from("theta"),
+                    index: 0,
+                }),
+            },
+        ];
+        assert_eq!(remainder.len(), 0);
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
     fn parse_set_scale() {
         let tokens = lex(r#"SET-SCALE 0 "rf" 1.0; SET-SCALE 0 1 "rf" theta"#);
         let (remainder, parsed) = parse_instructions(&tokens).unwrap();
@@ -538,6 +565,33 @@ mod tests {
                     qubits: vec![Qubit::Fixed(0), Qubit::Fixed(1)],
                 },
                 frequency: Expression::Address(MemoryReference {
+                    name: String::from("theta"),
+                    index: 0,
+                }),
+            },
+        ];
+        assert_eq!(remainder.len(), 0);
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn parse_shift_phase() {
+        let tokens = lex(r#"SHIFT-PHASE 0 "rf" 1.0; SHIFT-PHASE 0 1 "rf" theta"#);
+        let (remainder, parsed) = parse_instructions(&tokens).unwrap();
+        let expected = vec![
+            Instruction::ShiftPhase {
+                frame: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(0)],
+                },
+                phase: Expression::Number(real!(1.0)),
+            },
+            Instruction::ShiftPhase {
+                frame: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(0), Qubit::Fixed(1)],
+                },
+                phase: Expression::Address(MemoryReference {
                     name: String::from("theta"),
                     index: 0,
                 }),


### PR DESCRIPTION
A lot of these instructions are parsed exactly the same, so it feels kinda silly to have so many different functions to do it. Not sure how to deduplicate without just making it harder to use though so 🤷 