### PR TITLE
Upgrade: support equality between commutative expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ serde = { version = "1.0.125", features = ["derive"] }
 
 [dev-dependencies]
 insta = "1.7.1"
+proptest = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0.125", features = ["derive"] }
 [dev-dependencies]
 insta = "1.7.1"
 proptest = "1.0.0"
+proptest-derive = "0.3.0"

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -392,7 +392,6 @@ mod tests {
     use super::*;
     use crate::{instruction::MemoryReference, real};
     use num_complex::Complex64;
-    use proptest::num::f64::{NEGATIVE, NORMAL, POSITIVE, ZERO};
     use proptest::prelude::*;
     use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
     use std::f64::consts::PI;
@@ -471,10 +470,9 @@ mod tests {
     /// See https://docs.rs/proptest/1.0.0/proptest/prelude/trait.Strategy.html#method.prop_recursive
     fn arb_expr() -> impl Strategy<Value = Expression> {
         use Expression::*;
-        let num = NORMAL | POSITIVE | NEGATIVE | ZERO;
         let leaf = prop_oneof![
             any::<MemoryReference>().prop_map(Address),
-            (num, num).prop_map(|(re, im)| Number(num_complex::Complex64::new(re, im))),
+            (any::<f64>(), any::<f64>()).prop_map(|(re, im)| Number(num_complex::Complex64::new(re, im))),
             Just(PiConstant),
             ".*".prop_map(Variable),
         ];
@@ -509,7 +507,7 @@ mod tests {
     proptest! {
 
         #[test]
-        fn eq(a in NORMAL | POSITIVE | NEGATIVE | ZERO, b in NORMAL | POSITIVE | NEGATIVE | ZERO) {
+        fn eq(a in any::<f64>(), b in any::<f64>()) {
             let first = Expression::Infix {
                 left: Box::new(Expression::Number(real!(a))),
                 operator: InfixOperator::Plus,
@@ -522,7 +520,7 @@ mod tests {
         }
 
         #[test]
-        fn eq_commutative(a in NORMAL | POSITIVE | NEGATIVE | ZERO, b in NORMAL | POSITIVE | NEGATIVE | ZERO) {
+        fn eq_commutative(a in any::<f64>(), b in any::<f64>()) {
             let first = Expression::Infix{
                 left: Box::new(Expression::Number(real!(a))),
                 operator: InfixOperator::Plus,
@@ -537,7 +535,7 @@ mod tests {
         }
 
         #[test]
-        fn hash(a in NORMAL | POSITIVE | NEGATIVE | ZERO, b in NORMAL | POSITIVE | NEGATIVE | ZERO) {
+        fn hash(a in any::<f64>(), b in any::<f64>()) {
             let first = Expression::Infix {
                 left: Box::new(Expression::Number(real!(a))),
                 operator: InfixOperator::Plus,
@@ -552,7 +550,7 @@ mod tests {
         }
 
         #[test]
-        fn hash_commutative(a in NORMAL | POSITIVE | NEGATIVE | ZERO, b in NORMAL | POSITIVE | NEGATIVE | ZERO) {
+        fn hash_commutative(a in any::<f64>(), b in any::<f64>()) {
             let first = Expression::Infix{
                 left: Box::new(Expression::Number(real!(a))),
                 operator: InfixOperator::Plus,

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -472,7 +472,8 @@ mod tests {
         use Expression::*;
         let leaf = prop_oneof![
             any::<MemoryReference>().prop_map(Address),
-            (any::<f64>(), any::<f64>()).prop_map(|(re, im)| Number(num_complex::Complex64::new(re, im))),
+            (any::<f64>(), any::<f64>())
+                .prop_map(|(re, im)| Number(num_complex::Complex64::new(re, im))),
             Just(PiConstant),
             ".*".prop_map(Variable),
         ];

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -65,8 +65,7 @@ impl Hash for Expression {
         match self {
             Address(m) => {
                 "Address".hash(state);
-                m.name.hash(state);
-                m.index.hash(state);
+                m.hash(state);
             }
             FunctionCall {
                 function,

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -18,7 +18,8 @@ use std::{collections::HashMap, fmt};
 
 use crate::expression::Expression;
 
-#[cfg(test)] use proptest_derive::Arbitrary;
+#[cfg(test)]
+use proptest_derive::Arbitrary;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ArithmeticOperand {

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -18,6 +18,8 @@ use std::{collections::HashMap, fmt};
 
 use crate::expression::Expression;
 
+#[cfg(test)] use proptest_derive::Arbitrary;
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum ArithmeticOperand {
     LiteralInteger(i64),
@@ -200,6 +202,7 @@ impl fmt::Display for WaveformInvocation {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct MemoryReference {
     pub name: String,
     pub index: u64,


### PR DESCRIPTION
If we don't mind relying on hashing for equality, this might work. Building off of @dbanty's work in #25, I've handwritten `impl Hash for Expression`. Basically, the strategy is

1. hashing the name of the enumeration variant (e.g. `"Address".hash(state)`), then
2. hashing the stuff inside (if any)

In the case of `Number(Complex<f64>)`, we turn the floats into their `u64` bit representation ([the docs claim this is reasonable](https://doc.rust-lang.org/std/primitive.f64.html#method.to_bits)) and hash that. In the case of an infix expression with a commutative operator (addition or multiplication), we order the operands by the u64 values of _their_ hashes.

I've also expanded the testing with [`proptest`](https://docs.rs/proptest/1.0.0/proptest/index.html) to demonstrate that for any two "reasonable" (finite non-NAN) floats `a` and `b`, `Expression(a, +, b) == Expression(b, +, a)` and their hashes are equal as well.

I'm going to mark this as a draft for now; I'd like to extend test coverage of `Eq` and `Hash` to make sure this behaves as expected.