### PR TITLE
Evaluate patched memory addresses

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-use crate::{imag, instruction::MemoryReference, real};
 use std::collections::HashMap;
 use std::f64::consts::PI;
 use std::fmt;
+use std::str::FromStr;
+
+use crate::parser::{lex, parse_expression};
+use crate::{imag, instruction::MemoryReference, real};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EvaluationError {
@@ -81,14 +84,18 @@ impl Expression {
     /// Consume the expression, simplifying it as much as possible using the values provided in the environment.
     /// If variables are used in the expression which are not present in the environment, evaluation stops there,
     /// returning the possibly-simplified expression.
-    pub fn evaluate(self, environment: &EvaluationEnvironment) -> Self {
+    pub fn evaluate(
+        self,
+        environment: &EvaluationEnvironment,
+        patch_values: Option<&HashMap<&str, Vec<f64>>>,
+    ) -> Self {
         use Expression::*;
         match self {
             FunctionCall {
                 function,
                 expression,
             } => {
-                let evaluated = (*expression).evaluate(environment);
+                let evaluated = (*expression).evaluate(environment, patch_values);
                 match &evaluated {
                     Number(value) => Number(calculate_function(&function, value)),
                     PiConstant => Number(calculate_function(&function, &real!(PI))),
@@ -103,8 +110,8 @@ impl Expression {
                 operator,
                 right,
             } => {
-                let left_evaluated = (*left).evaluate(environment);
-                let right_evaluated = (*right).evaluate(environment);
+                let left_evaluated = (*left).evaluate(environment, patch_values);
+                let right_evaluated = (*right).evaluate(environment, patch_values);
 
                 match (&left_evaluated, &right_evaluated) {
                     (Number(value_left), Number(value_right)) => {
@@ -143,7 +150,17 @@ impl Expression {
                 Some(value) => Number(*value),
                 None => Variable(identifier),
             },
-            _ => self,
+            Address(memory_reference) => {
+                let number = patch_values.and_then(|patch_values| {
+                    let values = patch_values.get(memory_reference.name.as_str())?;
+                    let value = values.get(memory_reference.index as usize)?;
+                    Some(real!(*value))
+                });
+
+                number.map_or(Address(memory_reference), Number)
+            }
+            PiConstant => PiConstant,
+            Number(number) => Number(number),
         }
     }
 
@@ -152,10 +169,11 @@ impl Expression {
     pub fn evaluate_to_complex(
         self,
         environment: &EvaluationEnvironment,
+        patch_values: Option<&HashMap<&str, Vec<f64>>>,
     ) -> Result<num_complex::Complex64, EvaluationError> {
         use Expression::*;
 
-        let result = self.evaluate(environment);
+        let result = self.evaluate(environment, patch_values);
         match result {
             Number(value) => Ok(value),
             PiConstant => Ok(real!(PI)),
@@ -292,28 +310,36 @@ impl fmt::Display for InfixOperator {
 
 #[cfg(test)]
 mod tests {
-    use super::PrefixOperator;
+    use std::{collections::HashMap, f64::consts::PI};
+
+    use num_complex::Complex64;
+
     use crate::{
-        expression::{EvaluationError, Expression, ExpressionFunction, InfixOperator},
+        expression::{EvaluationError, Expression, ExpressionFunction},
         real,
     };
-    use num_complex::Complex64;
-    use std::{collections::HashMap, f64::consts::PI};
+
+    use super::*;
 
     #[test]
     fn evaluate() {
         use Expression::*;
 
-        let one = Complex64::new(1f64, 0f64);
+        let one = real!(1.0);
         let empty_environment = HashMap::new();
 
         let mut environment = HashMap::new();
         environment.insert("foo".to_owned(), real!(10f64));
         environment.insert("bar".to_owned(), real!(100f64));
 
+        let mut patch_values = HashMap::new();
+        patch_values.insert("theta", vec![1.0, 2.0]);
+        patch_values.insert("beta", vec![3.0, 4.0]);
+
         struct TestCase<'a> {
             expression: Expression,
             environment: &'a HashMap<String, Complex64>,
+            patch_values: Option<&'a HashMap<&'a str, Vec<f64>>>,
             evaluated_expression: Expression,
             evaluated_complex: Result<Complex64, EvaluationError>,
         }
@@ -322,6 +348,7 @@ mod tests {
             TestCase {
                 expression: Number(one),
                 environment: &empty_environment,
+                patch_values: None,
                 evaluated_expression: Number(one),
                 evaluated_complex: Ok(one),
             },
@@ -331,22 +358,21 @@ mod tests {
                     expression: Box::new(Number(real!(1f64))),
                 },
                 environment: &empty_environment,
+                patch_values: None,
                 evaluated_expression: Number(real!(-1f64)),
                 evaluated_complex: Ok(real!(-1f64)),
             },
             TestCase {
                 expression: Expression::Variable("foo".to_owned()),
                 environment: &environment,
+                patch_values: None,
                 evaluated_expression: Number(real!(10f64)),
                 evaluated_complex: Ok(real!(10f64)),
             },
             TestCase {
-                expression: Expression::Infix {
-                    left: Box::new(Expression::Variable("foo".to_owned())),
-                    operator: InfixOperator::Plus,
-                    right: Box::new(Expression::Variable("bar".to_owned())),
-                },
+                expression: Expression::from_str("%foo + %bar").unwrap(),
                 environment: &environment,
+                patch_values: None,
                 evaluated_expression: Number(real!(110f64)),
                 evaluated_complex: Ok(real!(110f64)),
             },
@@ -356,16 +382,27 @@ mod tests {
                     expression: Box::new(Expression::Number(real!(PI / 2f64))),
                 },
                 environment: &environment,
+                patch_values: None,
                 evaluated_expression: Number(real!(1f64)),
                 evaluated_complex: Ok(real!(1f64)),
+            },
+            TestCase {
+                expression: Expression::from_str("theta[1] * beta[0]").unwrap(),
+                environment: &empty_environment,
+                patch_values: Some(&patch_values),
+                evaluated_expression: Expression::from_str("6.0").unwrap(),
+                evaluated_complex: Ok(real!(6.0)),
             },
         ];
 
         for case in cases {
-            let evaluated = case.expression.evaluate(&case.environment);
+            let evaluated = case
+                .expression
+                .evaluate(case.environment, case.patch_values);
             assert_eq!(evaluated, case.evaluated_expression);
 
-            let evaluated_complex = evaluated.evaluate_to_complex(&case.environment);
+            let evaluated_complex =
+                evaluated.evaluate_to_complex(case.environment, case.patch_values);
             assert_eq!(evaluated_complex, case.evaluated_complex)
         }
     }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -182,6 +182,25 @@ impl Expression {
     }
 }
 
+impl<'a> FromStr for Expression {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let tokens = lex(s);
+        let (extra, expression) =
+            parse_expression(&tokens).map_err(|_| String::from("Failed to parse expression"))?;
+        if extra.is_empty() {
+            Ok(expression)
+        } else {
+            Err(format!(
+                "Parsed valid expression {} but found {} extra tokens",
+                expression,
+                extra.len(),
+            ))
+        }
+    }
+}
+
 /// Format a num_complex::Complex64 value in a way that omits the real or imaginary part when
 /// reasonable. That is:
 ///

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13,6 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+use nom::IResult;
+
+use error::Error;
+pub(crate) use expression::parse_expression;
+pub(crate) use instruction::parse_instructions;
+pub(crate) use lexer::lex;
+use lexer::Token;
+
 mod command;
 mod gate;
 mod macros;
@@ -22,14 +30,6 @@ mod error;
 mod expression;
 mod instruction;
 mod lexer;
-
-pub(crate) use instruction::parse_instructions;
-pub(crate) use lexer::lex;
-
-use nom::IResult;
-
-use error::Error;
-use lexer::Token;
 
 type ParserInput<'a> = &'a [Token];
 type ParserResult<'a, R> = IResult<&'a [Token], R, Error<&'a [Token]>>;

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -163,10 +163,10 @@ impl CalibrationSet {
                     .all(|(calibration_index, _)| {
                         let calibration_parameters = calibration.parameters[calibration_index]
                             .clone()
-                            .evaluate(&HashMap::new());
+                            .evaluate(&HashMap::new(), None);
                         let gate_parameters = gate_parameters[calibration_index]
                             .clone()
-                            .evaluate(&HashMap::new());
+                            .evaluate(&HashMap::new(), None);
                         match (calibration_parameters, gate_parameters) {
                             // If the calibration is variable, it matches any fixed qubit
                             (Expression::Variable(_), _) => true,


### PR DESCRIPTION
Two changes in here:

## Breaking: `Expression::evaluate` and `evaluate_to_complex` now take in a `patch_values` parameter.

`patch_values` allows for evaluating expressions that contain memory references in the same format used to send executables to QPUs.

##  New: Implement `FromStr` for `Expression`.

Enables creation of expressions from strings for easier testing (e.g. `Expression::from_str("theta" + "beta")`).

## Potential Issues

1. Obviously this is a breaking change, so downstream consumers will have to deal with that.
2. The error messaging on `FromStr` isn't great, but I think we intend on revamping errors overall in this crate so I didn't pull in `thiserror` or anything for it.
