### PR TITLE
feat: update program to use btreemap for deterministic ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quil-rs"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "indexmap",
  "insta",

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use crate::instruction::{
@@ -41,8 +41,8 @@ mod memory;
 pub struct Program {
     pub calibrations: CalibrationSet,
     pub frames: FrameSet,
-    pub memory_regions: HashMap<String, MemoryRegion>,
-    pub waveforms: HashMap<String, Waveform>,
+    pub memory_regions: BTreeMap<String, MemoryRegion>,
+    pub waveforms: BTreeMap<String, Waveform>,
     pub instructions: Vec<Instruction>,
 }
 
@@ -51,8 +51,8 @@ impl Program {
         Program {
             calibrations: CalibrationSet::new(),
             frames: FrameSet::new(),
-            memory_regions: HashMap::new(),
-            waveforms: HashMap::new(),
+            memory_regions: BTreeMap::new(),
+            waveforms: BTreeMap::new(),
             instructions: vec![],
         }
     }
@@ -240,7 +240,7 @@ impl FromStr for Program {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{collections::BTreeMap, iter::FromIterator, str::FromStr};
 
     use super::Program;
 
@@ -338,5 +338,17 @@ DEFCAL I 0:
 I 0
 "
         );
+    }
+
+    #[test]
+    fn program_deterministic_ordering() {
+        const MEMORIES: &[&str; 3] = &["DECLARE ro BIT;", "DECLARE anc BIT;", "DECLARE ec BIT;"];
+        let input = &MEMORIES.concat();
+        let program1 = Program::from_str(input).unwrap().to_string(true);
+        let program2 = Program::from_str(input).unwrap().to_string(true);
+
+        // verify that each memory declaration in the program is in the same index as the same
+        // program after being re-parsed and serialized.
+        assert!(program1.lines().eq(program2.lines()));
     }
 }


### PR DESCRIPTION
This was causing snapshot test failures when a program was serialized and compared to a cached version of itself from a prior run. Specifically, the memory regions of a program would serialize out-of-order & while that should not have any impact on the program itself, it creates false-positives when testing. 

The use of a `HashMap` is replaced with a `BTreeMap` throughout a `Program`, including the `waveforms` field. The test included in this PR does not necessarily help differentiate or prove the new behavior compared to the `HashMap` version, but it does help to ensure that we see the expected behavior.

This change fixes the broken test (in another repo) which lead to this PR. 