### PR TITLE
Update: latest Cargo.lock version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quil-rs"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "indexmap",
  "insta",


### PR DESCRIPTION
This PR is to trigger a release, after learning about the semantics of our semantic-release automation. However, it will also act as a test to see if the automation updates & adds `Cargo.lock` to a commit prior to release (effectively making the same kind of change in this PR). 