### PR TITLE
test use of criterion default baselines with archive

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,3 @@
-# Based on https://github.com/actions-rs/meta/blob/master/recipes/msrv.md
-
 on: [ push, pull_request ]
 
 name: Benchmark
@@ -7,11 +5,13 @@ name: Benchmark
 jobs:
   benchmark:
     name: Run benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         rust:
           - stable
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: bench.yml
-          name: benchmarks
+          name: benchmarks-${{ matrix.os }}
           path: target/criterion
         continue-on-error: true
       
@@ -38,12 +38,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with: 
           command: bench
-          args: --bench parser -- --warm-up-time=2 --measurement-time=2 --sample-size=500 --color=always
+          args: --bench parser -- --warm-up-time=2 --measurement-time=3 --sample-size=500 --color=always
       
       - name: Archive benchmark results
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main'}}
         uses: actions/upload-artifact@v3
         with:
-          name: benchmarks
+          name: benchmarks-${{ matrix.os }}
           path: target/criterion
     

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,6 @@
 # Based on https://github.com/actions-rs/meta/blob/master/recipes/msrv.md
 
-on: [ pull_request ]
+on: [ push, pull_request ]
 
 name: Benchmark
 
@@ -17,15 +17,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-          fetch-depth: 0
-
-      - name: Set env vars
-        run: |
-          THIS_SHA=$(echo $GITHUB_SHA | cut -c 1-7)
-          MAIN_SHA=$(echo $(git rev-parse main) | cut -c 1-7)
-
-          echo "THIS_BENCH=${THIS_SHA}.bench" >> $GITHUB_ENV
-          echo "MAIN_BENCH=${MAIN_SHA}.bench" >> $GITHUB_ENV
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
@@ -34,33 +25,25 @@ jobs:
           override: true
         
       - uses: Swatinem/rust-cache@v1
-        
-      - name: Install critcmp
-        run: cargo install critcmp
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
+    
+      - name: Download benchmark artifacts
+        uses: dawidd6/action-download-artifact@v2
         with:
-          command: check
-
-      # - name: Download benchmark artifacts
-      #   uses: actions/download-artifact@v3
-      #   with:
-      #     name: benchmarks
+          workflow: bench.yml
+          name: benchmarks
+          path: target/criterion
+        continue-on-error: true
       
       - name: Run cargo benchmark
         uses: actions-rs/cargo@v1
         with: 
           command: bench
-          args: --bench parser -- --save-baseline $THIS_SHA
+          args: --bench parser -- --warm-up-time=2 --measurement-time=2 --sample-size=500 --color=always
       
       - name: Archive benchmark results
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v3
         with:
           name: benchmarks
           path: target/criterion
-      
-      # - name: Compare benchmark to main
-      #   run: |
-      #     echo "comparing this benchmark to $MAIN_BENCH (main)"
-      #     critcmp $MAIN_BENCH $THIS_BENCH
+    


### PR DESCRIPTION
Simplify & correct the download/archive flow for benchmark results. Each PR will be benchmarked against the current `base` result. When the branch is `main`, the `base` result is archived for use in the next workflow run. 

Upon merging to `main`, the benchmark should run again and archive its results.