### PR TITLE
Fix: change quilc submodule to use HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "benches/quilc"]
 	path = benches/quilc
-	url = git@github.com:quil-lang/quilc.git
+	url = https://github.com/quil-lang/quilc.git


### PR DESCRIPTION
This caused an issue in CI, which doesn't have an SSH key to provide for github auth. Unnecessary anyway -- the quilc repo is public.