### PR TITLE
feat: support ternary logic instructions

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -104,6 +104,44 @@ impl fmt::Display for UnaryOperator {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub enum TernaryOperand {
+    LiteralInteger(i64),
+    LiteralReal(f64),
+    MemoryReference(MemoryReference),
+}
+
+impl fmt::Display for TernaryOperand {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self {
+            TernaryOperand::LiteralInteger(value) => write!(f, "{}", value),
+            TernaryOperand::LiteralReal(value) => write!(f, "{}", value),
+            TernaryOperand::MemoryReference(value) => write!(f, "{}", value),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TernaryOperator {
+    Equal,
+    GreaterThanOrEqual,
+    GreaterThan,
+    LessThanOrEqual,
+    LessThan,
+}
+
+impl fmt::Display for TernaryOperator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self {
+            TernaryOperator::Equal => write!(f, "EQ"),
+            TernaryOperator::GreaterThanOrEqual => write!(f, "GE"),
+            TernaryOperator::GreaterThan => write!(f, "GT"),
+            TernaryOperator::LessThanOrEqual => write!(f, "LE"),
+            TernaryOperator::LessThan => write!(f, "LT"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub enum AttributeValue {
     String(String),
     Expression(Expression),
@@ -411,6 +449,12 @@ pub struct Arithmetic {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct TernaryLogic {
+    pub operator: TernaryOperator,
+    pub operands: (MemoryReference, MemoryReference, TernaryOperand),
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct BinaryLogic {
     pub operator: BinaryOperator,
     pub operands: (MemoryReference, BinaryOperand),
@@ -493,6 +537,7 @@ pub enum Instruction {
     SwapPhases(SwapPhases),
     WaveformDefinition(WaveformDefinition),
     Arithmetic(Arithmetic),
+    TernaryLogic(TernaryLogic),
     BinaryLogic(BinaryLogic),
     UnaryLogic(UnaryLogic),
     Halt,
@@ -541,6 +586,7 @@ impl From<&Instruction> for InstructionRole {
             | Instruction::ShiftPhase(_)
             | Instruction::SwapPhases(_) => InstructionRole::RFControl,
             Instruction::Arithmetic(_)
+            | Instruction::TernaryLogic(_)
             | Instruction::BinaryLogic(_)
             | Instruction::UnaryLogic(_)
             | Instruction::Move(_)
@@ -863,6 +909,13 @@ impl fmt::Display for Instruction {
                 write!(f, "JUMP-WHEN @{} {}", target, condition)
             }
             Instruction::Label(Label(label)) => write!(f, "LABEL @{}", label),
+            Instruction::TernaryLogic(TernaryLogic { operator, operands }) => {
+                write!(
+                    f,
+                    "{} {} {} {}",
+                    operator, operands.0, operands.1, operands.2
+                )
+            }
             Instruction::BinaryLogic(BinaryLogic { operator, operands }) => {
                 write!(f, "{} {} {}", operator, operands.0, operands.1)
             }

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -23,8 +23,8 @@ use crate::instruction::{
     Arithmetic, ArithmeticOperand, ArithmeticOperator, BinaryLogic, BinaryOperator, Calibration,
     Capture, CircuitDefinition, Declaration, Delay, Exchange, Fence, FrameDefinition, Instruction,
     Jump, JumpUnless, JumpWhen, Label, Load, Measurement, Move, Pragma, Pulse, RawCapture, Reset,
-    SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, UnaryLogic, UnaryOperator,
-    Waveform, WaveformDefinition,
+    SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, TernaryLogic,
+    TernaryOperator, UnaryLogic, UnaryOperator, Waveform, WaveformDefinition,
 };
 use crate::parser::common::parse_variable_qubit;
 use crate::parser::instruction::parse_block;
@@ -54,6 +54,25 @@ pub fn parse_arithmetic(
             operator,
             destination,
             source,
+        }),
+    ))
+}
+
+/// Parse a logical ternary instruction of the form `addr addr ( addr | INT | REAL )`.
+/// Called using the logical operator itself (such as `EQ`) which should be previously parsed.
+pub fn parse_logical_ternary(
+    operator: TernaryOperator,
+    input: ParserInput,
+) -> ParserResult<Instruction> {
+    let (input, destination) = common::parse_memory_reference(input)?;
+    let (input, left) = common::parse_memory_reference(input)?;
+    let (input, right) = common::parse_ternary_logic_operand(input)?;
+
+    Ok((
+        input,
+        Instruction::TernaryLogic(TernaryLogic {
+            operator,
+            operands: (destination, left, right),
         }),
     ))
 }

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -27,7 +27,7 @@ use crate::{
     expression::Expression,
     instruction::{
         ArithmeticOperand, AttributeValue, BinaryOperand, FrameIdentifier, GateModifier,
-        MemoryReference, Qubit, ScalarType, Vector, WaveformInvocation,
+        MemoryReference, Qubit, ScalarType, TernaryOperand, Vector, WaveformInvocation,
     },
     parser::lexer::Operator,
     token,
@@ -65,9 +65,36 @@ pub fn parse_arithmetic_operand<'a>(input: ParserInput<'a>) -> ParserResult<'a, 
                 ArithmeticOperand::LiteralInteger(sign * (v as i64))
             },
         ),
-        map(parse_memory_reference, |f| {
-            ArithmeticOperand::MemoryReference(f)
-        }),
+        map(parse_memory_reference, ArithmeticOperand::MemoryReference),
+    ))(input)
+}
+
+/// Parse the operand of a ternary instruction, which may be a literal integer, literal real number, or memory reference.
+pub fn parse_ternary_logic_operand<'a>(input: ParserInput<'a>) -> ParserResult<'a, TernaryOperand> {
+    alt((
+        map(
+            tuple((opt(token!(Operator(o))), token!(Float(v)))),
+            |(op, v)| {
+                let sign = match op {
+                    None => 1f64,
+                    Some(Operator::Minus) => -1f64,
+                    _ => panic!("Implement this error"), // TODO
+                };
+                TernaryOperand::LiteralReal(sign * v)
+            },
+        ),
+        map(
+            tuple((opt(token!(Operator(o))), token!(Integer(v)))),
+            |(op, v)| {
+                let sign = match op {
+                    None => 1,
+                    Some(Operator::Minus) => -1,
+                    _ => panic!("Implement this error"), // TODO
+                };
+                TernaryOperand::LiteralInteger(sign * (v as i64))
+            },
+        ),
+        map(parse_memory_reference, TernaryOperand::MemoryReference),
     ))(input)
 }
 
@@ -85,9 +112,7 @@ pub fn parse_binary_logic_operand<'a>(input: ParserInput<'a>) -> ParserResult<'a
                 BinaryOperand::LiteralInteger(sign * (v as i64))
             },
         ),
-        map(parse_memory_reference, |f| {
-            BinaryOperand::MemoryReference(f)
-        }),
+        map(parse_memory_reference, BinaryOperand::MemoryReference),
     ))(input)
 }
 

--- a/src/program/graph.rs
+++ b/src/program/graph.rs
@@ -511,6 +511,7 @@ impl ScheduledProgram {
             let instruction_index = Some(index);
             match instruction {
                 Instruction::Arithmetic(_)
+                | Instruction::TernaryLogic(_)
                 | Instruction::BinaryLogic(_)
                 | Instruction::UnaryLogic(_)
                 | Instruction::Capture(_)

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -173,6 +173,7 @@ impl Program {
             | Instruction::Pragma(_)
             | Instruction::WaveformDefinition(_)
             | Instruction::Arithmetic(_)
+            | Instruction::TernaryLogic(_)
             | Instruction::BinaryLogic(_)
             | Instruction::UnaryLogic(_)
             | Instruction::Halt


### PR DESCRIPTION
Adds support for `EQ, LT, LE, GT, GE` instructions as per [Quil spec #6-5Classical-Instructions](https://quil-lang.github.io/#6-5Classical-Instructions)

