### PR TITLE
Add Expression.to_real()

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  **/
 use std::collections::{hash_map::DefaultHasher, HashMap};
+use std::convert::TryInto;
 use std::f64::consts::PI;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -330,6 +331,15 @@ impl Expression {
             Expression::Number(_) => Err(EvaluationError::NumberNotReal),
             _ => Err(EvaluationError::NotANumber),
         }
+    }
+}
+
+/// If this is a number with imaginary part "equal to" zero (of _small_ absolute value), return
+/// that number. Otherwise, error with an evaluation error of a descriptive type.
+impl TryInto<f64> for Expression {
+    type Error = EvaluationError;
+    fn try_into(self) -> Result<f64, Self::Error> {
+        self.to_real()
     }
 }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  **/
 use std::collections::{hash_map::DefaultHasher, HashMap};
-use std::convert::TryInto;
 use std::f64::consts::PI;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -26,10 +25,14 @@ use proptest_derive::Arbitrary;
 use crate::parser::{lex, parse_expression};
 use crate::{imag, instruction::MemoryReference, real};
 
+/// The different possible types of errors that could occur during expression evaluation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EvaluationError {
+    /// There wasn't enough information to completely evaluate an expression.
     Incomplete,
+    /// An operation expected a real number but received a complex one.
     NumberNotReal,
+    /// An operation expected a number but received a different type of expression.
     NotANumber,
 }
 
@@ -331,15 +334,6 @@ impl Expression {
             Expression::Number(_) => Err(EvaluationError::NumberNotReal),
             _ => Err(EvaluationError::NotANumber),
         }
-    }
-}
-
-/// If this is a number with imaginary part "equal to" zero (of _small_ absolute value), return
-/// that number. Otherwise, error with an evaluation error of a descriptive type.
-impl TryInto<f64> for Expression {
-    type Error = EvaluationError;
-    fn try_into(self) -> Result<f64, Self::Error> {
-        self.to_real()
     }
 }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -688,12 +688,17 @@ mod tests {
         }
 
         #[test]
-        fn eq_implies_hash_eq(x in arb_expr(), y in arb_expr()) {
-            let mut s = DefaultHasher::new();
-            x.hash(&mut s);
-            let h_x = s.finish();
-            y.hash(&mut s);
-            let h_y = s.finish();
+        fn eq_iff_hash_eq(x in arb_expr(), y in arb_expr()) {
+            let h_x = {
+                let mut s = DefaultHasher::new();
+                x.hash(&mut s);
+                s.finish()
+            };
+            let h_y = {
+                let mut s = DefaultHasher::new();
+                y.hash(&mut s);
+                s.finish()
+            };
             prop_assert_eq!(x == y, h_x == h_y);
         }
 


### PR DESCRIPTION
In using this library elsewhere, I've noticed folks doing something like

```rust
match x {
    case Expression::Number(x) if x.im == 0.0 => {
      ...
    },
    ...
}
```

which to me seems

1. repetitive, since we'd like to just match on a real number and move on with our lives; and
2. error-prone, since it's conceivable (however unlikely) that we might have an expression that algebraically _should_ be a real number but has a non-zero but _wicked_ tiny imaginary part due to rounding issues from other computation.

This PR creates `Expression.to_real() -> Result<f64, EvaluationError>` and adds two descriptive types of `EvaluationError`.